### PR TITLE
Use same Babel targets as other libraries

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,11 @@
 {
     "sourceMaps": true,
     "presets": [
-        "@babel/preset-env",
+        ["@babel/preset-env", {
+            "targets": [
+                "last 2 Chrome versions", "last 2 Firefox versions", "last 2 Safari versions"
+            ]
+        }],
         "@babel/preset-typescript"
     ],
     "plugins": [


### PR DESCRIPTION
This signals to Babel that most modern syntax is safe to use, resulting in much
smaller, easier to read compiled output.

Noticed while investigating https://github.com/vector-im/element-web/issues/15493