### PR TITLE
Replace event emitter with a simple bus

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,14 +33,11 @@
     "@babel/plugin-proposal-class-properties": "^7.10.4",
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-typescript": "^7.10.4",
-    "@types/events": "^3.0.0",
     "babel-eslint": "^10.1.0",
     "eslint": "^7.8.1",
     "eslint-config-matrix-org": "^0.1.2",
     "eslint-plugin-babel": "^5.3.1",
     "rimraf": "^3.0.2"
   },
-  "dependencies": {
-    "events": "^3.2.0"
-  }
+  "dependencies": {}
 }

--- a/src/ClientWidgetApi.ts
+++ b/src/ClientWidgetApi.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { EventEmitter } from "events";
 import { ITransport } from "./transport/ITransport";
 import { Widget } from "./models/Widget";
 import { PostmessageTransport } from "./transport/PostmessageTransport";
@@ -40,6 +39,7 @@ import {
     IModalWidgetOpenRequestDataButton,
     IModalWidgetReturnData,
 } from "./interfaces/ModalWidgetActions";
+import { EventEmitter } from "./util/EventEmitter";
 
 /**
  * API handler for the client side of widgets. This raises events
@@ -65,7 +65,7 @@ import {
  *
  * This class only handles one widget at a time.
  */
-export class ClientWidgetApi extends EventEmitter {
+export class ClientWidgetApi extends EventEmitter<CustomEvent> {
     public readonly transport: ITransport;
 
     private capabilitiesFinished = false;

--- a/src/WidgetApi.ts
+++ b/src/WidgetApi.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { EventEmitter } from "events";
 import { Capability } from "./interfaces/Capabilities";
 import { IWidgetApiRequest, IWidgetApiRequestEmptyData } from "./interfaces/IWidgetApiRequest";
 import { WidgetApiDirection } from "./interfaces/WidgetApiDirection";
@@ -44,6 +43,7 @@ import {
     IModalWidgetOpenRequestDataButton,
     IModalWidgetReturnData,
 } from "./interfaces/ModalWidgetActions";
+import { EventEmitter } from "./util/EventEmitter";
 
 /**
  * API handler for widgets. This raises events for each action
@@ -62,7 +62,7 @@ import {
  * raise a "ready" CustomEvent. After the ready event fires, actions
  * can be sent and the transport will be ready.
  */
-export class WidgetApi extends EventEmitter {
+export class WidgetApi extends EventEmitter<CustomEvent> {
     public readonly transport: ITransport;
 
     private capabilitiesFinished = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,8 @@ export * from "./models/Widget";
 export * from "./models/WidgetParser";
 
 // Utilities
+// Dev note: we don't export our EventEmitter or EnhancedMap utilities because
+// they confuse IDEs and aren't relevant to this package.
 export * from "./templating/url-template";
 
 // Drivers

--- a/src/transport/ITransport.ts
+++ b/src/transport/ITransport.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { EventEmitter } from "events";
 import {
     IWidgetApiAcknowledgeResponseData,
     IWidgetApiRequest,
@@ -23,6 +22,7 @@ import {
     IWidgetApiResponseData,
     WidgetApiAction,
 } from "..";
+import { EventEmitter } from "../util/EventEmitter";
 
 /**
  * A transport for widget requests/responses. All actions

--- a/src/transport/PostmessageTransport.ts
+++ b/src/transport/PostmessageTransport.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { EventEmitter } from "events";
 import { ITransport } from "./ITransport";
+import { EventEmitter } from "../util/EventEmitter";
 import {
     invertedDirection,
     isErrorResponse,

--- a/src/util/EventEmitter.ts
+++ b/src/util/EventEmitter.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { EnhancedMap } from "./maps";
+
+export interface EventListener<T> {
+    (ev: T): void;
+}
+
+export class EventEmitter<T = Object> {
+    private listeners = new EnhancedMap<string, EventListener<T>[]>();
+
+    /**
+     * Emits an event. Not guranteed to be sync.
+     * @param {string} eventName The event name.
+     * @param {T} ev The event payload (optional).
+     * @protected
+     */
+    protected emit(eventName: string, ev: T = null) {
+        const listeners = this.listeners.get(eventName);
+        if (!listeners) return;
+
+        for (const listener of listeners) {
+            try {
+                listener(ev);
+            } catch (e) {
+                console.error(`Error raising event '${eventName}': `, e);
+            }
+        }
+    }
+
+    public on(eventName: string, cb: EventListener<T>) {
+        this.listeners.getOrCreate(eventName, []).push(cb);
+    }
+
+    public off(eventName: string, cb: EventListener<T>) {
+        const listeners = this.listeners.getOrCreate(eventName, []);
+        const idx = listeners.indexOf(cb);
+        if (idx >= 0) listeners.splice(idx, 1);
+    }
+
+    public once(eventName: string, cb: EventListener<T>) {
+        let called = false;
+        const wrapFn: EventListener<T> = (ev: T) => {
+            if (called) return;
+            called = true;
+            this.off(eventName, wrapFn);
+            cb(ev);
+        };
+        this.on(eventName, wrapFn);
+    }
+}
+

--- a/src/util/maps.ts
+++ b/src/util/maps.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * A Map<K, V> with added utility.
+ */
+export class EnhancedMap<K, V> extends Map<K, V> {
+    public constructor(entries?: Iterable<[K, V]>) {
+        super(entries);
+    }
+
+    public getOrCreate(key: K, def: V): V {
+        if (this.has(key)) {
+            return this.get(key);
+        }
+        this.set(key, def);
+        return def;
+    }
+
+    public remove(key: K): V {
+        const v = this.get(key);
+        this.delete(key);
+        return v;
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -894,11 +894,6 @@
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
 
-"@types/events@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
-  integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
-
 "@types/json-schema@^7.0.3":
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
@@ -1830,11 +1825,6 @@ esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
-
-events@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/events/-/events-3.2.0.tgz#93b87c18f8efcd4202a461aec4dfc0556b639379"
-  integrity sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==
 
 expand-brackets@^2.1.4:
   version "2.1.4"


### PR DESCRIPTION
There are some linkup issues with the `events` implementation that can cause faulty and dangerous builds. Instead of trying to fight the system, we can just implement the bare minimum we need/expect.