### PR TITLE
Add support for MSC2871: Notifying the widget of its capabilities

### DIFF
--- a/src/interfaces/ApiVersion.ts
+++ b/src/interfaces/ApiVersion.ts
@@ -22,6 +22,7 @@ export enum MatrixApiVersion {
 
 export enum UnstableApiVersion {
     MSC2762 = "org.matrix.msc2762",
+    MSC2871 = "org.matrix.msc2871",
 }
 
 export type ApiVersion = MatrixApiVersion | UnstableApiVersion | string;
@@ -31,4 +32,5 @@ export const CurrentApiVersions: ApiVersion[] = [
     MatrixApiVersion.Prerelease2,
     MatrixApiVersion.V010,
     UnstableApiVersion.MSC2762,
+    UnstableApiVersion.MSC2871,
 ];

--- a/src/interfaces/CapabilitiesAction.ts
+++ b/src/interfaces/CapabilitiesAction.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { IWidgetApiRequest, IWidgetApiRequestEmptyData } from "./IWidgetApiRequest";
+import { IWidgetApiRequest, IWidgetApiRequestData, IWidgetApiRequestEmptyData } from "./IWidgetApiRequest";
 import { WidgetApiToWidgetAction } from "./WidgetApiAction";
 import { Capability } from "./Capabilities";
-import { IWidgetApiResponseData } from "./IWidgetApiResponse";
+import { IWidgetApiAcknowledgeResponseData, IWidgetApiResponseData } from "./IWidgetApiResponse";
 
 export interface ICapabilitiesActionRequest extends IWidgetApiRequest {
     action: WidgetApiToWidgetAction.Capabilities;
@@ -30,4 +30,18 @@ export interface ICapabilitiesActionResponseData extends IWidgetApiResponseData 
 
 export interface ICapabilitiesActionResponse extends ICapabilitiesActionRequest {
     response: ICapabilitiesActionResponseData;
+}
+
+export interface INotifyCapabilitiesActionRequestData extends IWidgetApiRequestData {
+    requested: Capability[];
+    approved: Capability[];
+}
+
+export interface INotifyCapabilitiesActionRequest extends IWidgetApiRequest {
+    action: WidgetApiToWidgetAction.NotifyCapabilities;
+    data: INotifyCapabilitiesActionRequestData;
+}
+
+export interface INotifyCapabilitiesActionResponse extends INotifyCapabilitiesActionRequest {
+    response: IWidgetApiAcknowledgeResponseData;
 }

--- a/src/interfaces/WidgetApiAction.ts
+++ b/src/interfaces/WidgetApiAction.ts
@@ -17,6 +17,7 @@
 export enum WidgetApiToWidgetAction {
     SupportedApiVersions = "supported_api_versions",
     Capabilities = "capabilities",
+    NotifyCapabilities = "notify_capabilities",
     TakeScreenshot = "screenshot",
     UpdateVisibility = "visibility",
     OpenIDCredentials = "openid_credentials",


### PR DESCRIPTION
This causes the `ready` event of the `WidgetApi` to change to when the client notifies the widget of its approved capabilities (when the client supports the MSC).

MSC2871: https://github.com/matrix-org/matrix-doc/pull/2871