### PR TITLE
Support the updated parsing of event capabilities in MSC2762

### DIFF
--- a/src/WidgetApi.ts
+++ b/src/WidgetApi.ts
@@ -52,6 +52,7 @@ import {
 } from "./interfaces/ModalWidgetActions";
 import { ISetModalButtonEnabledActionRequestData } from "./interfaces/SetModalButtonEnabledAction";
 import { ISendEventFromWidgetRequestData, ISendEventFromWidgetResponseData } from "./interfaces/SendEventAction";
+import { EventDirection, WidgetEventCapability } from "./models/WidgetEventCapability";
 
 /**
  * API handler for widgets. This raises events for each action
@@ -135,6 +136,70 @@ export class WidgetApi extends EventEmitter {
      */
     public requestCapabilities(capabilities: Capability[]) {
         capabilities.forEach(cap => this.requestCapability(cap));
+    }
+
+    /**
+     * Requests the capability to send a given state event with optional explicit
+     * state key. It is not guaranteed to be allowed, but will be asked for if the
+     * negotiation has not already happened.
+     * @param {string} eventType The state event type to ask for.
+     * @param {string} stateKey If specified, the specific state key to request.
+     * Otherwise all state keys will be requested.
+     */
+    public requestCapabilityToSendState(eventType: string, stateKey?: string) {
+        this.requestCapability(WidgetEventCapability.forStateEvent(EventDirection.Send, eventType, stateKey).raw);
+    }
+
+    /**
+     * Requests the capability to receive a given state event with optional explicit
+     * state key. It is not guaranteed to be allowed, but will be asked for if the
+     * negotiation has not already happened.
+     * @param {string} eventType The state event type to ask for.
+     * @param {string} stateKey If specified, the specific state key to request.
+     * Otherwise all state keys will be requested.
+     */
+    public requestCapabilityToReceiveState(eventType: string, stateKey?: string) {
+        this.requestCapability(WidgetEventCapability.forStateEvent(EventDirection.Receive, eventType, stateKey).raw);
+    }
+
+    /**
+     * Requests the capability to send a given room event. It is not guaranteed to be
+     * allowed, but will be asked for if the negotiation has not already happened.
+     * @param {string} eventType The room event type to ask for.
+     */
+    public requestCapabilityToSendEvent(eventType: string) {
+        this.requestCapability(WidgetEventCapability.forRoomEvent(EventDirection.Send, eventType).raw);
+    }
+
+    /**
+     * Requests the capability to receive a given room event. It is not guaranteed to be
+     * allowed, but will be asked for if the negotiation has not already happened.
+     * @param {string} eventType The room event type to ask for.
+     */
+    public requestCapabilityToReceiveEvent(eventType: string) {
+        this.requestCapability(WidgetEventCapability.forRoomEvent(EventDirection.Receive, eventType).raw);
+    }
+
+    /**
+     * Requests the capability to send a given message event with optional explicit
+     * `msgtype`. It is not guaranteed to be allowed, but will be asked for if the
+     * negotiation has not already happened.
+     * @param {string} msgtype If specified, the specific msgtype to request.
+     * Otherwise all message types will be requested.
+     */
+    public requestCapabilityToSendMessage(msgtype?: string) {
+        this.requestCapability(WidgetEventCapability.forRoomMessageEvent(EventDirection.Send, msgtype).raw);
+    }
+
+    /**
+     * Requests the capability to receive a given message event with optional explicit
+     * `msgtype`. It is not guaranteed to be allowed, but will be asked for if the
+     * negotiation has not already happened.
+     * @param {string} msgtype If specified, the specific msgtype to request.
+     * Otherwise all message types will be requested.
+     */
+    public requestCapabilityToReceiveMessage(msgtype?: string) {
+        this.requestCapability(WidgetEventCapability.forRoomMessageEvent(EventDirection.Receive, msgtype).raw);
     }
 
     /**

--- a/src/models/WidgetEventCapability.ts
+++ b/src/models/WidgetEventCapability.ts
@@ -127,7 +127,7 @@ export class WidgetEventCapability {
             // so we split on that. However, a # is also valid in either one of those so we
             // join accordingly.
             // Eg: `m.room.message##m.text` is "m.room.message" event with msgtype "#m.text".
-            let expectingKeyStr = eventSegment.startsWith("m.room.message#") || isState;
+            const expectingKeyStr = eventSegment.startsWith("m.room.message#") || isState;
             let keyStr: string = null;
             if (eventSegment.includes('#') && expectingKeyStr) {
                 // Dev note: regex is difficult to write, so instead the rules are manually written

--- a/src/models/WidgetEventCapability.ts
+++ b/src/models/WidgetEventCapability.ts
@@ -17,8 +17,8 @@
 import { Capability } from "..";
 
 export enum EventDirection {
-    Send,
-    Receive,
+    Send = "send",
+    Receive = "receive",
 }
 
 export class WidgetEventCapability {
@@ -54,6 +54,37 @@ export class WidgetEventCapability {
 
         // Default not allowed
         return false;
+    }
+
+    public static forStateEvent(
+        direction: EventDirection,
+        eventType: string,
+        stateKey?: string,
+    ): WidgetEventCapability {
+        // TODO: Enable support for m.* namespace once the MSC lands.
+        eventType = eventType.replace(/#/g, '\\#');
+        stateKey = stateKey !== null && stateKey !== undefined ? `#${stateKey}` : '';
+        const str = `org.matrix.msc2762.${direction}.state_event:${eventType}${stateKey}`;
+
+        // cheat by sending it through the processor
+        return WidgetEventCapability.findEventCapabilities([str])[0];
+    }
+
+    public static forRoomEvent(direction: EventDirection, eventType: string): WidgetEventCapability {
+        // TODO: Enable support for m.* namespace once the MSC lands.
+        const str = `org.matrix.msc2762.${direction}.event:${eventType}`;
+
+        // cheat by sending it through the processor
+        return WidgetEventCapability.findEventCapabilities([str])[0];
+    }
+
+    public static forRoomMessageEvent(direction: EventDirection, msgtype?: string): WidgetEventCapability {
+        // TODO: Enable support for m.* namespace once the MSC lands.
+        msgtype = msgtype === null || msgtype === undefined ? '' : msgtype;
+        const str = `org.matrix.msc2762.${direction}.event:m.room.message#${msgtype}`;
+
+        // cheat by sending it through the processor
+        return WidgetEventCapability.findEventCapabilities([str])[0];
     }
 
     /**
@@ -96,11 +127,37 @@ export class WidgetEventCapability {
             // so we split on that. However, a # is also valid in either one of those so we
             // join accordingly.
             // Eg: `m.room.message##m.text` is "m.room.message" event with msgtype "#m.text".
+            let expectingKeyStr = eventSegment.startsWith("m.room.message#") || isState;
             let keyStr: string = null;
-            if (eventSegment.includes('#')) {
+            if (eventSegment.includes('#') && expectingKeyStr) {
+                // Dev note: regex is difficult to write, so instead the rules are manually written
+                // out. This is probably just as understandable as a boring regex though, so win-win?
+
+                // Test cases:
+                // str                      eventSegment        keyStr
+                // -------------------------------------------------------------
+                // m.room.message#          m.room.message      <empty string>
+                // m.room.message#test      m.room.message      test
+                // m.room.message\#         m.room.message#     test
+                // m.room.message##test     m.room.message      #test
+                // m.room.message\##test    m.room.message#     test
+                // m.room.message\\##test   m.room.message\#    test
+                // m.room.message\\###test  m.room.message\#    #test
+
+                // First step: explode the string
                 const parts = eventSegment.split('#');
-                eventSegment = parts[0];
-                keyStr = parts.slice(1).join('#');
+
+                // To form the eventSegment, we'll keep finding parts of the exploded string until
+                // there's one that doesn't end with the escape character (\). We'll then join those
+                // segments together with the exploding character. We have to remember to consume the
+                // escape character as well.
+                const idx = parts.findIndex(p => !p.endsWith("\\"));
+                eventSegment = parts.slice(0, idx + 1)
+                    .map(p => p.endsWith('\\') ? p.substring(0, p.length - 1) : p)
+                    .join('#');
+
+                // The keyStr is whatever is left over.
+                keyStr = parts.slice(idx + 1).join('#');
             }
 
             parsed.push(new WidgetEventCapability(direction, eventSegment, isState, keyStr, cap));

--- a/src/models/WidgetEventCapability.ts
+++ b/src/models/WidgetEventCapability.ts
@@ -62,6 +62,7 @@ export class WidgetEventCapability {
         stateKey?: string,
     ): WidgetEventCapability {
         // TODO: Enable support for m.* namespace once the MSC lands.
+        // https://github.com/matrix-org/matrix-widget-api/issues/22
         eventType = eventType.replace(/#/g, '\\#');
         stateKey = stateKey !== null && stateKey !== undefined ? `#${stateKey}` : '';
         const str = `org.matrix.msc2762.${direction}.state_event:${eventType}${stateKey}`;
@@ -72,6 +73,7 @@ export class WidgetEventCapability {
 
     public static forRoomEvent(direction: EventDirection, eventType: string): WidgetEventCapability {
         // TODO: Enable support for m.* namespace once the MSC lands.
+        // https://github.com/matrix-org/matrix-widget-api/issues/22
         const str = `org.matrix.msc2762.${direction}.event:${eventType}`;
 
         // cheat by sending it through the processor
@@ -80,6 +82,7 @@ export class WidgetEventCapability {
 
     public static forRoomMessageEvent(direction: EventDirection, msgtype?: string): WidgetEventCapability {
         // TODO: Enable support for m.* namespace once the MSC lands.
+        // https://github.com/matrix-org/matrix-widget-api/issues/22
         msgtype = msgtype === null || msgtype === undefined ? '' : msgtype;
         const str = `org.matrix.msc2762.${direction}.event:m.room.message#${msgtype}`;
 
@@ -100,6 +103,7 @@ export class WidgetEventCapability {
             let isState = false;
 
             // TODO: Enable support for m.* namespace once the MSC lands.
+            // https://github.com/matrix-org/matrix-widget-api/issues/22
 
             if (cap.startsWith("org.matrix.msc2762.send.")) {
                 if (cap.startsWith("org.matrix.msc2762.send.event:")) {


### PR DESCRIPTION
Updates:
* https://github.com/matrix-org/matrix-doc/pull/2762/commits/8ad19262f68bda1e57e369a0245b618bbc9841a1
* https://github.com/matrix-org/matrix-doc/pull/2762/commits/3aa58ee029f923ecdffe8b307fd328d984881647

In slightly more detail: this introduces the escaping mechanics as well as limiting the parsing to expected event types.