### PR TITLE
Add from widget "completed" action

### DIFF
--- a/src/WidgetApi.ts
+++ b/src/WidgetApi.ts
@@ -343,6 +343,14 @@ export class WidgetApi extends EventEmitter {
     }
 
     /**
+     * Tell the client that we have completed with whatever we might have wanted to do.
+     * @returns {Promise} Resolves when the client acknowledges the request.
+     */
+    public sendCompleted(): Promise<void> {
+        return this.transport.send(WidgetApiFromWidgetAction.Completed, <IWidgetApiRequestEmptyData>{}).then();
+    }
+
+    /**
      * Starts the communication channel. This should be done early to ensure
      * that messages are not missed. Communication can only be stopped by the client.
      */

--- a/src/interfaces/CompletedAction.ts
+++ b/src/interfaces/CompletedAction.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { IWidgetApiRequest, IWidgetApiRequestEmptyData } from "./IWidgetApiRequest";
+import { WidgetApiFromWidgetAction } from "./WidgetApiAction";
+import { IWidgetApiAcknowledgeResponseData, IWidgetApiResponse } from "./IWidgetApiResponse";
+
+export interface IWidgetConfigRequest extends IWidgetApiRequest {
+    action: WidgetApiFromWidgetAction.Completed;
+    data: IWidgetApiRequestEmptyData;
+}
+
+export interface IWidgetConfigResponse extends IWidgetApiResponse {
+    response: IWidgetApiAcknowledgeResponseData;
+}

--- a/src/interfaces/WidgetApiAction.ts
+++ b/src/interfaces/WidgetApiAction.ts
@@ -37,6 +37,7 @@ export enum WidgetApiFromWidgetAction {
     OpenModalWidget = "open_modal",
     SetModalButtonEnabled = "set_button_enabled",
     SendEvent = "send_event",
+    Completed = "completed"
 }
 
 export type WidgetApiAction = WidgetApiToWidgetAction | WidgetApiFromWidgetAction | string;


### PR DESCRIPTION
This allows widgets to signal that they are now complete, with
whatever it is they wanted to do. This could for example be
used to tell the client user that they are now safe to close
a modal widget, should there be such restrictions that the
modal should not be closed before the widget has completed.

This is different from requesting to close the widget, since
we might still have information visible to the user.