### PR TITLE
Update example: change url param to userId

### DIFF
--- a/examples/widget/index.html
+++ b/examples/widget/index.html
@@ -27,7 +27,7 @@
         An easy web server can be made with the http-server NPM package.
 
         Once served, use the following command to add the widget to a room:
-            /addwidget http://localhost:8080/#/?widgetId=$matrix_widget_id&user_id=$matrix_user_id
+            /addwidget http://localhost:8080/#/?widgetId=$matrix_widget_id&userId=$matrix_user_id
 
         The widget should then load and present an interface for sticking the
         widget to the screen (if approved for the capability). It is recommended


### PR DESCRIPTION
The JS code looks for `userId`, not `user_id`. With the current example the initialisation fails.