### PR TITLE
Support MSC2931 navigation

### DIFF
--- a/src/WidgetApi.ts
+++ b/src/WidgetApi.ts
@@ -53,6 +53,7 @@ import {
 import { ISetModalButtonEnabledActionRequestData } from "./interfaces/SetModalButtonEnabledAction";
 import { ISendEventFromWidgetRequestData, ISendEventFromWidgetResponseData } from "./interfaces/SendEventAction";
 import { EventDirection, WidgetEventCapability } from "./models/WidgetEventCapability";
+import { INavigateActionRequestData } from "./interfaces/NavigateAction";
 
 /**
  * API handler for widgets. This raises events for each action
@@ -339,6 +340,24 @@ export class WidgetApi extends EventEmitter {
         }
         return this.transport.send<ISetModalButtonEnabledActionRequestData>(
             WidgetApiFromWidgetAction.SetModalButtonEnabled, {button: buttonId, enabled: isEnabled},
+        ).then();
+    }
+
+    /**
+     * Attempts to navigate the client to the given URI. This can only be called with Matrix URIs
+     * (currently only matrix.to, but in future a Matrix URI scheme will be defined).
+     * @param {string} uri The URI to navigate to.
+     * @returns {Promise<void>} Resolves when complete.
+     * @throws Throws if the URI is invalid or cannot be processed.
+     * @deprecated This currently relies on an unstable MSC (MSC2931).
+     */
+    public navigateTo(uri: string): Promise<void> {
+        if (!uri || !uri.startsWith("https://matrix.to/#")) {
+            throw new Error("Invalid matrix.to URI");
+        }
+
+        return this.transport.send<INavigateActionRequestData>(
+            WidgetApiFromWidgetAction.MSC2931Navigate, {uri},
         ).then();
     }
 

--- a/src/driver/WidgetDriver.ts
+++ b/src/driver/WidgetDriver.ts
@@ -93,7 +93,7 @@ export abstract class WidgetDriver {
      * @returns {Promise<void>} Resolves when complete.
      * @throws Throws if there's a problem with the navigation, such as invalid format.
      */
-    public async navigate(uri: string): Promise<void> {
+    public navigate(uri: string): Promise<void> {
         throw new Error("Navigation is not implemented");
     }
 }

--- a/src/driver/WidgetDriver.ts
+++ b/src/driver/WidgetDriver.ts
@@ -83,4 +83,17 @@ export abstract class WidgetDriver {
     public askOpenID(observer: SimpleObservable<IOpenIDUpdate>) {
         observer.update({state: OpenIDRequestState.Blocked});
     }
+
+    /**
+     * Navigates the client with a matrix.to URI. In future this function will also be provided
+     * with the Matrix URIs once matrix.to is replaced. The given URI will have already been
+     * lightly checked to ensure it looks like a valid URI, though the implementation is recommended
+     * to do further checks on the URI.
+     * @param {string} uri The URI to navigate to.
+     * @returns {Promise<void>} Resolves when complete.
+     * @throws Throws if there's a problem with the navigation, such as invalid format.
+     */
+    public async navigate(uri: string): Promise<void> {
+        throw new Error("Navigation is not implemented");
+    }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ export * from "./interfaces/SetModalButtonEnabledAction";
 export * from "./interfaces/WidgetConfigAction";
 export * from "./interfaces/SendEventAction";
 export * from "./interfaces/IRoomEvent";
+export * from "./interfaces/NavigateAction";
 
 // Complex models
 export * from "./models/WidgetEventCapability";

--- a/src/interfaces/ApiVersion.ts
+++ b/src/interfaces/ApiVersion.ts
@@ -23,6 +23,7 @@ export enum MatrixApiVersion {
 export enum UnstableApiVersion {
     MSC2762 = "org.matrix.msc2762",
     MSC2871 = "org.matrix.msc2871",
+    MSC2931 = "org.matrix.msc2931",
 }
 
 export type ApiVersion = MatrixApiVersion | UnstableApiVersion | string;
@@ -33,4 +34,5 @@ export const CurrentApiVersions: ApiVersion[] = [
     //MatrixApiVersion.V010,
     UnstableApiVersion.MSC2762,
     UnstableApiVersion.MSC2871,
+    UnstableApiVersion.MSC2931,
 ];

--- a/src/interfaces/NavigateAction.ts
+++ b/src/interfaces/NavigateAction.ts
@@ -14,18 +14,19 @@
  * limitations under the License.
  */
 
-export enum MatrixCapabilities {
-    Screenshots = "m.capability.screenshot",
-    StickerSending = "m.sticker",
-    AlwaysOnScreen = "m.always_on_screen",
+import { IWidgetApiRequest, IWidgetApiRequestData, IWidgetApiRequestEmptyData } from "./IWidgetApiRequest";
+import { WidgetApiFromWidgetAction } from "./WidgetApiAction";
+import { IWidgetApiAcknowledgeResponseData } from "./IWidgetApiResponse";
 
-    /**
-     * @deprecated It is not recommended to rely on this existing - it can be removed without notice.
-     */
-    MSC2931Navigate = "org.matrix.msc2931.navigate",
+export interface INavigateActionRequest extends IWidgetApiRequest {
+    action: WidgetApiFromWidgetAction.MSC2931Navigate;
+    data: INavigateActionRequestData;
 }
 
-export type Capability = MatrixCapabilities | string;
+export interface INavigateActionRequestData extends IWidgetApiRequestData {
+    uri: string;
+}
 
-export const StickerpickerCapabilities: Capability[] = [MatrixCapabilities.StickerSending];
-export const VideoConferenceCapabilities: Capability[] = [MatrixCapabilities.AlwaysOnScreen];
+export interface INavigateActionResponse extends INavigateActionRequest {
+    response: IWidgetApiAcknowledgeResponseData;
+}

--- a/src/interfaces/NavigateAction.ts
+++ b/src/interfaces/NavigateAction.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { IWidgetApiRequest, IWidgetApiRequestData, IWidgetApiRequestEmptyData } from "./IWidgetApiRequest";
+import { IWidgetApiRequest, IWidgetApiRequestData } from "./IWidgetApiRequest";
 import { WidgetApiFromWidgetAction } from "./WidgetApiAction";
 import { IWidgetApiAcknowledgeResponseData } from "./IWidgetApiResponse";
 

--- a/src/interfaces/WidgetApiAction.ts
+++ b/src/interfaces/WidgetApiAction.ts
@@ -37,6 +37,11 @@ export enum WidgetApiFromWidgetAction {
     OpenModalWidget = "open_modal",
     SetModalButtonEnabled = "set_button_enabled",
     SendEvent = "send_event",
+
+    /**
+     * @deprecated It is not recommended to rely on this existing - it can be removed without notice.
+     */
+    MSC2931Navigate = "org.matrix.msc2931.navigate",
 }
 
 export type WidgetApiAction = WidgetApiToWidgetAction | WidgetApiFromWidgetAction | string;


### PR DESCRIPTION
MSC: https://github.com/matrix-org/matrix-doc/pull/2931
See https://github.com/matrix-org/matrix-react-sdk/pull/5527

This experiments with a new way of handling unstable features from MSCs by using `@deprecated` on the entry points into the system.