### PR TITLE
Add @types/events to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@babel/plugin-proposal-class-properties": "^7.10.4",
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-typescript": "^7.10.4",
-    "@types/events": "^3.0.0",
     "babel-eslint": "^10.1.0",
     "browserify": "^17.0.0",
     "eslint": "^7.8.1",
@@ -47,6 +46,7 @@
     "tinyify": "^3.0.0"
   },
   "dependencies": {
+    "@types/events": "^3.0.0",
     "events": "^3.2.0"
   }
 }


### PR DESCRIPTION
Moves `@types/events` from devDependencies to dependencies. When a user just installs `matrix-widget-api`, the definitions for the `WidgetApi.on` function will not exist.