### PR TITLE
Rename room ID to indicate new meaning

### DIFF
--- a/src/templating/url-template.ts
+++ b/src/templating/url-template.ts
@@ -17,7 +17,7 @@
 import { IWidget } from "..";
 
 export interface ITemplateParams {
-    currentRoomId?: string;
+    widgetRoomId?: string;
     currentUserId: string;
     userDisplayName?: string;
     userHttpAvatarUrl?: string;
@@ -26,7 +26,7 @@ export interface ITemplateParams {
 export function runTemplate(url: string, widget: IWidget, params: ITemplateParams): string {
     // Always apply the supplied params over top of data to ensure the data can't lie about them.
     const variables = Object.assign({}, widget.data, {
-        matrix_room_id: params.currentRoomId || "",
+        matrix_room_id: params.widgetRoomId || "",
         matrix_user_id: params.currentUserId,
         matrix_display_name: params.userDisplayName || params.currentUserId,
         matrix_avatar_url: params.userHttpAvatarUrl || "",


### PR DESCRIPTION
This renames the URL templating data to make it clear that the room ID is locked
to the room where the widget was added (instead of being the currently viewed
room).

Relates to https://github.com/vector-im/element-web/issues/16337
Used by https://github.com/matrix-org/matrix-react-sdk/pull/5607