### PR TITLE
Allow modal widget buttons to be disabled when the modal opens

### DIFF
--- a/src/interfaces/ModalWidgetActions.ts
+++ b/src/interfaces/ModalWidgetActions.ts
@@ -38,6 +38,7 @@ export interface IModalWidgetOpenRequestDataButton {
     id: ModalButtonID;
     label: string;
     kind: ModalButtonKind | string;
+    disabled: boolean;
 }
 
 export interface IModalWidgetOpenRequestData extends IModalWidgetCreateData, Omit<IWidget, "id" | "creatorUserId"> {

--- a/src/interfaces/ModalWidgetActions.ts
+++ b/src/interfaces/ModalWidgetActions.ts
@@ -38,7 +38,7 @@ export interface IModalWidgetOpenRequestDataButton {
     id: ModalButtonID;
     label: string;
     kind: ModalButtonKind | string;
-    disabled: boolean;
+    disabled?: boolean;
 }
 
 export interface IModalWidgetOpenRequestData extends IModalWidgetCreateData, Omit<IWidget, "id" | "creatorUserId"> {


### PR DESCRIPTION
This is a small change that would allow us to initialize modal widget buttons as disabled.

Related PR: https://github.com/matrix-org/matrix-react-sdk/pull/6178

Signed-off-by: Steffen Kolmer steffen.kolmer@nordeck.net