### PR TITLE
Emit event after capability re/negotiation

### DIFF
--- a/src/ClientWidgetApi.ts
+++ b/src/ClientWidgetApi.ts
@@ -205,8 +205,8 @@ export class ClientWidgetApi extends EventEmitter {
             approved: Array.from(this.allowedCapabilities),
         }).catch(e => {
             console.warn("non-fatal error notifying widget of approved capabilities:", e);
-        }).then(_ => {
-            this.emit("capabilities_renegotiated")
+        }).then(() => {
+            this.emit("capabilitiesNotified")
         });
     }
 


### PR DESCRIPTION
This is required for: https://github.com/matrix-org/matrix-react-sdk/pull/7005 (to update the popout button when the permission is added after the initial setup already is done)
The WidgetClientApi emits an event `capabilities_renegotiated` when new capabilities were added to the the allowed array.
A listener to this event is also the preferred place to handle any reaction a client could have for a widget capability change (like displaying the permissions the widget has).
