### PR TITLE
Call beginCapabilities again when iframe reloads

### DIFF
--- a/src/ClientWidgetApi.ts
+++ b/src/ClientWidgetApi.ts
@@ -170,11 +170,9 @@ export class ClientWidgetApi extends EventEmitter {
 
     private onIframeLoad(ev: Event) {
         this.beginCapabilities();
-
     }
 
     private beginCapabilities() {
-
         // widget has loaded - tell all the listeners that
         this.emit("preparing");
 

--- a/src/ClientWidgetApi.ts
+++ b/src/ClientWidgetApi.ts
@@ -171,14 +171,9 @@ export class ClientWidgetApi extends EventEmitter {
     private onIframeLoad(ev: Event) {
         this.beginCapabilities();
 
-        // We don't need the listener anymore
-        this.iframe.removeEventListener("onload", this.onIframeLoad.bind(this));
     }
 
     private beginCapabilities() {
-        if (this.capabilitiesFinished) {
-            throw new Error("Capabilities exchange already completed");
-        }
 
         // widget has loaded - tell all the listeners that
         this.emit("preparing");

--- a/src/ClientWidgetApi.ts
+++ b/src/ClientWidgetApi.ts
@@ -90,10 +90,8 @@ import { Symbols } from "./Symbols";
 export class ClientWidgetApi extends EventEmitter {
     public readonly transport: ITransport;
 
-    // contentLoadedActionSent is used to check that only one ContentLoaded request is send in the correct order.
-    // To enforce the correct order, the initial value is true and gets set to false after the Iframe load event.
-    // Only than ContentLoaded actions are allowed.
-    private contentLoadedActionSent = true;
+    // contentLoadedActionSent is used to check that only one ContentLoaded request is send.
+    private contentLoadedActionSent = false;
     private allowedCapabilities = new Set<Capability>();
     private allowedEvents: WidgetEventCapability[] = [];
     private isStopped = false;


### PR DESCRIPTION
Fixes: https://github.com/vector-im/element-web/issues/15866

This is a draft for discussion.

The way I understand it is, that the ready event in the WidgetApi is only emitted in the `handleCapabilities` function.
This event is needed for the widget to load.
Reloading the Iframe also needs to emit "ready" in the widgetApi. This can only be achieved by the `WidgetApiToWidgetAction.Capabilities` action. (receiving this action calls the `handleCapabilities` function).
But the only place this action is send is in: `beginCapabilities` of the WidgetClientApi.

So it should not be skipped even if the capabilities are already finished `capabilitiesFinished`. 
I don't see the issue with allowing beginCapabilities to be called again when the "load" event from the I frame is triggered. Am I missing something?


Another approach would be to reset the widget on the "load" event from the Iframe IF `capabilitiesFinished` is true.


Works: roomState: {"waitForIframeLoad":false}
```html
<script type="text/javascript">
    try {
        // Set up the widget API as soon as possible to avoid problems with the client
        const widgetApi = new mxwidgets.WidgetApi(widgetId);
        widgetApi.requestCapability(mxwidgets.MatrixCapabilities.AlwaysOnScreen);

        widgetApi.on("ready", function() {
            // Fill in the basic widget details now that we're allowed to operate.
            document.getElementById("container").innerHTML = "Hello <span id='userId'></span>!<br /><br />"
                + "Currently stuck on screen: <span id='stickyState'></span><br /><br />"
                + "<button onclick='toggleSticky()'>Toggle sticky state</button>";

            // Fill in the user ID using innerText to avoid XSS
            document.getElementById("userId").innerText = userId;
        });
        function loaded() {
            console.log("document has Loaded")
            widgetApi.sendContentLoaded();
        }

        // Start the widget as soon as possible too, otherwise the client might time us out.
        widgetApi.start();
    } catch (e) {
        handleError(e);
    }
    </script>
 ```
works:  roomState: {"waitForIframeLoad":true}
```html
    <script type="text/javascript">
    try {
        // Set up the widget API as soon as possible to avoid problems with the client
        const widgetApi = new mxwidgets.WidgetApi(widgetId);
        widgetApi.requestCapability(mxwidgets.MatrixCapabilities.AlwaysOnScreen);

        widgetApi.on("ready", function() {
            // Fill in the basic widget details now that we're allowed to operate.
            document.getElementById("container").innerHTML = "Hello <span id='userId'></span>!<br /><br />"
                + "Currently stuck on screen: <span id='stickyState'></span><br /><br />"
                + "<button onclick='toggleSticky()'>Toggle sticky state</button>";

            // Fill in the user ID using innerText to avoid XSS
            document.getElementById("userId").innerText = userId;
        });
        function loaded() {
            console.log("document has Loaded")
           //  widgetApi.sendContentLoaded();
        }

        // Start the widget as soon as possible too, otherwise the client might time us out.
        widgetApi.start();
    } catch (e) {
        handleError(e);
    }
    </script>
```
Throws Error: {"waitForIframeLoad":true}
```html
    <script type="text/javascript">
    try {
        // Set up the widget API as soon as possible to avoid problems with the client
        const widgetApi = new mxwidgets.WidgetApi(widgetId);
        widgetApi.requestCapability(mxwidgets.MatrixCapabilities.AlwaysOnScreen);

        widgetApi.on("ready", function() {
            // Fill in the basic widget details now that we're allowed to operate.
            document.getElementById("container").innerHTML = "Hello <span id='userId'></span>!<br /><br />"
                + "Currently stuck on screen: <span id='stickyState'></span><br /><br />"
                + "<button onclick='toggleSticky()'>Toggle sticky state</button>";

            // Fill in the user ID using innerText to avoid XSS
            document.getElementById("userId").innerText = userId;
        });

        function loaded() {
            console.log("document has Loaded")
            // THROWS AN ERROR IF 
           widgetApi.sendContentLoaded();
        }

        // Start the widget as soon as possible too, otherwise the client might time us out.
        widgetApi.start();
        // ALWAYS THROWS AN ERROR: {"waitForIframeLoad":true}
        widgetApi.sendContentLoaded();
    } catch (e) {
        handleError(e);
    }
    </script>
```