### PR TITLE
Deprecate RequiresClient as it will be moved

### DIFF
--- a/src/interfaces/Capabilities.ts
+++ b/src/interfaces/Capabilities.ts
@@ -20,7 +20,10 @@ export enum MatrixCapabilities {
     Screenshots = "m.capability.screenshot",
     StickerSending = "m.sticker",
     AlwaysOnScreen = "m.always_on_screen",
-    // Ask Element to not give the option to move the widget into a separate tab.
+    /**
+     * @deprecated It is not recommended to rely on this existing - it can be removed without notice.
+     * Ask Element to not give the option to move the widget into a separate tab.
+     */
     RequiresClient = "io.element.requires_client",
     /**
      * @deprecated It is not recommended to rely on this existing - it can be removed without notice.


### PR DESCRIPTION
This PR fixes vector-im/element-web#20920 by deprecating RequiresClient as it will be moved to ElementWidgetCapabilities.
See also matrix-org/matrix-react-sdk#7935

Signed-off-by: Robin Kouwenhoven <r.kouwenhoven@outlook.com>

<!-- Please read https://github.com/matrix-org/matrix-widget-api/blob/master/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-widget-api/blob/master/CONTRIBUTING.md#sign-off -->
