### PR TITLE
Remove the stability warning from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ JavaScript/TypeScript SDK for widgets & clients to communicate.
 
 For help and support, visit [#matrix-widgets:matrix.org](https://matrix.to/#/#matrix-widgets:matrix.org) on Matrix.
 
-## Not yet ready for usage
+*Disclaimer: Widgets are not yet in the Matrix spec, so this library may not work with other implementations.*
 
-This is currently not validated and thus should not be relied upon until this notice goes away. Installation
-instructions will take this notice's place.
+## Building
+
+To transpile this project to JavaScript, run `yarn build`.
 
 ## Using the API without a bundler
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,12 @@ For help and support, visit [#matrix-widgets:matrix.org](https://matrix.to/#/#ma
 
 ## Building
 
-To transpile this project to JavaScript, run `yarn build`.
+To transpile this project to JavaScript, run:
+
+```
+yarn install
+yarn build
+```
 
 ## Using the API without a bundler
 


### PR DESCRIPTION
in preparation for v1.0.0. Travis has OK'd the removal of this warning out-of-band.