### PR TITLE
Specify that to-device messages must be objects

### DIFF
--- a/src/WidgetApi.ts
+++ b/src/WidgetApi.ts
@@ -399,7 +399,7 @@ export class WidgetApi extends EventEmitter {
     public sendToDevice(
         eventType: string,
         encrypted: boolean,
-        contentMap: { [userId: string]: { [deviceId: string]: unknown } },
+        contentMap: { [userId: string]: { [deviceId: string]: object } },
     ): Promise<ISendToDeviceFromWidgetResponseData> {
         return this.transport.send<ISendToDeviceFromWidgetRequestData, ISendToDeviceFromWidgetResponseData>(
             WidgetApiFromWidgetAction.SendToDevice,

--- a/src/driver/WidgetDriver.ts
+++ b/src/driver/WidgetDriver.ts
@@ -87,7 +87,7 @@ export abstract class WidgetDriver {
     public sendToDevice(
         eventType: string,
         encrypted: boolean,
-        contentMap: { [userId: string]: { [deviceId: string]: unknown } },
+        contentMap: { [userId: string]: { [deviceId: string]: object } },
     ): Promise<void> {
         return Promise.reject(new Error("Failed to override function"));
     }

--- a/src/interfaces/SendToDeviceAction.ts
+++ b/src/interfaces/SendToDeviceAction.ts
@@ -22,7 +22,7 @@ import { IRoomEvent } from "./IRoomEvent";
 export interface ISendToDeviceFromWidgetRequestData extends IWidgetApiRequestData {
     type: string;
     encrypted: boolean;
-    messages: { [userId: string]: { [deviceId: string]: unknown } };
+    messages: { [userId: string]: { [deviceId: string]: object } };
 }
 
 export interface ISendToDeviceFromWidgetActionRequest extends IWidgetApiRequest {


### PR DESCRIPTION
That's what they are in the spec, so might as well make that explicit in the types here.