### PR TITLE
Catch exceptions from the widget driver in the event relations endpoint

### DIFF
--- a/src/ClientWidgetApi.ts
+++ b/src/ClientWidgetApi.ts
@@ -591,7 +591,8 @@ export class ClientWidgetApi extends EventEmitter {
             const result = await this.driver.readEventRelations(
                 request.data.event_id, request.data.room_id, request.data.rel_type,
                 request.data.event_type, request.data.from, request.data.to,
-                request.data.limit, request.data.direction);
+                request.data.limit, request.data.direction,
+            );
 
             // check if the user is permitted to receive the event in question
             if (result.originalEvent) {

--- a/test/ClientWidgetApi-test.ts
+++ b/test/ClientWidgetApi-test.ts
@@ -245,7 +245,6 @@ describe('ClientWidgetApi', () => {
             );
         });
 
-
         it('should reject requests without event_id', async () => {
             const event: IWidgetApiRequest = {
                 api: WidgetApiDirection.FromWidget,
@@ -342,6 +341,30 @@ describe('ClientWidgetApi', () => {
             await waitFor(() => {
                 expect(transport.reply).toBeCalledWith(event, {
                     error: { message: 'Cannot read state events of this type' },
+                });
+            });
+        });
+
+        it('should reject requests when the driver throws an exception', async () => {
+            driver.readEventRelations.mockRejectedValue(
+                new Error("M_FORBIDDEN: You don't have permission to access that event"),
+            );
+
+            const event: IReadRelationsFromWidgetActionRequest = {
+                api: WidgetApiDirection.FromWidget,
+                widgetId: 'test',
+                requestId: '0',
+                action: WidgetApiFromWidgetAction.MSC3869ReadRelations,
+                data: { event_id: '$event' },
+            };
+
+            await loadIframe();
+
+            emitEvent(new CustomEvent('', { detail: event }));
+
+            await waitFor(() => {
+                expect(transport.reply).toBeCalledWith(event, {
+                    error: { message: 'Unexpected error while reading relations' },
                 });
             });
         });


### PR DESCRIPTION
<!-- Please read https://github.com/matrix-org/matrix-widget-api/blob/master/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-widget-api/blob/master/CONTRIBUTING.md#sign-off -->

This is a follow up to #72.

The driver can throw an exception, e.g. when the referenced event doesn't exist or when the user is not authorized to see it due to the configured history visibility rules. Without this change, the call times out because the error is not forwarded via the transport channel.