### PR TITLE
Make `getClientVersions` public

### DIFF
--- a/src/WidgetApi.ts
+++ b/src/WidgetApi.ts
@@ -637,7 +637,7 @@ export class WidgetApi extends EventEmitter {
         });
     }
 
-    private getClientVersions(): Promise<ApiVersion[]> {
+    public getClientVersions(): Promise<ApiVersion[]> {
         if (Array.isArray(this.cachedClientVersions)) {
             return Promise.resolve(this.cachedClientVersions);
         }

--- a/test/WidgetApi-test.ts
+++ b/test/WidgetApi-test.ts
@@ -94,4 +94,34 @@ describe('WidgetApi', () => {
             )).rejects.toThrow('An error occurred');
         });
     });
+
+    describe('getClientVersions', () => {
+        beforeEach(() => {
+            jest.mocked(PostmessageTransport.prototype.send).mockResolvedValueOnce(
+                {
+                    supported_versions: [
+                        UnstableApiVersion.MSC3869, UnstableApiVersion.MSC2762,
+                    ],
+                } as ISupportedVersionsActionResponseData,
+            );
+        })
+
+        it('should request supported client versions', async () => {
+            await expect(widgetApi.getClientVersions()).resolves.toEqual([
+                'org.matrix.msc3869', 'org.matrix.msc2762',
+            ]);
+        })
+
+        it('should cache supported client versions on successive calls', async () => {
+            await expect(widgetApi.getClientVersions()).resolves.toEqual([
+                'org.matrix.msc3869', 'org.matrix.msc2762',
+            ]);
+
+            await expect(widgetApi.getClientVersions()).resolves.toEqual([
+                'org.matrix.msc3869', 'org.matrix.msc2762',
+            ]);
+
+            expect(PostmessageTransport.prototype.send).toBeCalledTimes(1);
+        })
+    });
 });


### PR DESCRIPTION
This makes the `getClientVersions` function on `WidgetApi` public and tests it. 

It is quite useful that the versions are exchanged between client and widget, so that the widget knows which capabilities the client has. But up to now, a widget can not access these details. We recently add #72 which evolves the API, but for now there is no way to detect whether it is really supported before running into errors. We would prefer to make a check and notify the user that he has to update to a newer Element version.

<!-- Please read https://github.com/matrix-org/matrix-widget-api/blob/master/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-widget-api/blob/master/CONTRIBUTING.md#sign-off -->
