### PR TITLE
Remove unspecced `original_event` field from the `readEventRelations` response

### DIFF
--- a/src/ClientWidgetApi.ts
+++ b/src/ClientWidgetApi.ts
@@ -594,23 +594,6 @@ export class ClientWidgetApi extends EventEmitter {
                 request.data.limit, request.data.direction,
             );
 
-            // check if the user is permitted to receive the event in question
-            if (result.originalEvent) {
-                if (result.originalEvent.state_key !== undefined) {
-                    if (!this.canReceiveStateEvent(result.originalEvent.type, result.originalEvent.state_key)) {
-                        return this.transport.reply<IWidgetApiErrorResponseData>(request, {
-                            error: { message: "Cannot read state events of this type" },
-                        });
-                    }
-                } else {
-                    if (!this.canReceiveRoomEvent(result.originalEvent.type, result.originalEvent.content['msgtype'])) {
-                        return this.transport.reply<IWidgetApiErrorResponseData>(request, {
-                            error: { message: "Cannot read room events of this type" },
-                        });
-                    }
-                }
-            }
-
             // only return events that the user has the permission to receive
             const chunk = result.chunk.filter(e => {
                 if (e.state_key !== undefined) {
@@ -623,7 +606,6 @@ export class ClientWidgetApi extends EventEmitter {
             return this.transport.reply<IReadRelationsFromWidgetResponseData>(
                 request,
                 {
-                    original_event: result.originalEvent,
                     chunk,
                     prev_batch: result.prevBatch,
                     next_batch: result.nextBatch,

--- a/src/driver/WidgetDriver.ts
+++ b/src/driver/WidgetDriver.ts
@@ -27,7 +27,6 @@ export interface IOpenIDUpdate {
 }
 
 export interface IReadEventRelationsResult {
-    originalEvent?: IRoomEvent;
     chunk: IRoomEvent[];
     nextBatch?: string;
     prevBatch?: string;

--- a/src/interfaces/ReadRelationsAction.ts
+++ b/src/interfaces/ReadRelationsAction.ts
@@ -37,7 +37,6 @@ export interface IReadRelationsFromWidgetActionRequest extends IWidgetApiRequest
 }
 
 export interface IReadRelationsFromWidgetResponseData extends IWidgetApiResponseData {
-    original_event: IRoomEvent | undefined; // eslint-disable-line camelcase
     chunk: IRoomEvent[];
 
     next_batch?: string; // eslint-disable-line camelcase

--- a/test/ClientWidgetApi-test.ts
+++ b/test/ClientWidgetApi-test.ts
@@ -130,7 +130,6 @@ describe('ClientWidgetApi', () => {
 
         it('should handle and process the request', async () => {
             driver.readEventRelations.mockResolvedValue({
-                originalEvent: createRoomEvent(),
                 chunk: [createRoomEvent()],
             });
 
@@ -150,7 +149,6 @@ describe('ClientWidgetApi', () => {
 
             await waitFor(() => {
                 expect(transport.reply).toBeCalledWith(event, {
-                    original_event: createRoomEvent(),
                     chunk: [createRoomEvent()],
                 });
             });
@@ -163,7 +161,6 @@ describe('ClientWidgetApi', () => {
 
         it('should only return events that match requested capabilities', async () => {
             driver.readEventRelations.mockResolvedValue({
-                originalEvent: createRoomEvent(),
                 chunk: [
                     createRoomEvent(),
                     createRoomEvent({ type: 'm.reaction' }),
@@ -189,7 +186,6 @@ describe('ClientWidgetApi', () => {
 
             await waitFor(() => {
                 expect(transport.reply).toBeCalledWith(event, {
-                    original_event: createRoomEvent(),
                     chunk: [
                         createRoomEvent(),
                         createRoomEvent({ type: 'net.example.test', state_key: 'A' }),
@@ -205,7 +201,6 @@ describe('ClientWidgetApi', () => {
 
         it('should accept all options and pass it to the driver', async () => {
             driver.readEventRelations.mockResolvedValue({
-                originalEvent: undefined,
                 chunk: [],
             });
 
@@ -234,7 +229,6 @@ describe('ClientWidgetApi', () => {
 
             await waitFor(() => {
                 expect(transport.reply).toBeCalledWith(event, {
-                    original_event: undefined,
                     chunk: [],
                 });
             });
@@ -296,52 +290,6 @@ describe('ClientWidgetApi', () => {
 
             expect(transport.reply).toBeCalledWith(event, {
                 error: { message: 'Unable to access room timeline: !another-room-id' },
-            });
-        });
-
-        it('should reject requests when the widget misses the capability to receive the room event type', async () => {
-            driver.readEventRelations.mockResolvedValue({
-                originalEvent: createRoomEvent(),
-                chunk: [],
-            });
-
-            const event: IReadRelationsFromWidgetActionRequest = {
-                api: WidgetApiDirection.FromWidget,
-                widgetId: 'test',
-                requestId: '0',
-                action: WidgetApiFromWidgetAction.MSC3869ReadRelations,
-                data: { event_id: '$event' },
-            };
-
-            emitEvent(new CustomEvent('', { detail: event }));
-
-            await waitFor(() => {
-                expect(transport.reply).toBeCalledWith(event, {
-                    error: { message: 'Cannot read room events of this type' },
-                });
-            });
-        });
-
-        it('should reject requests when the widget misses the capability to receive the state event type', async () => {
-            driver.readEventRelations.mockResolvedValue({
-                originalEvent: createRoomEvent({ state_key: '' }),
-                chunk: [],
-            });
-
-            const event: IReadRelationsFromWidgetActionRequest = {
-                api: WidgetApiDirection.FromWidget,
-                widgetId: 'test',
-                requestId: '0',
-                action: WidgetApiFromWidgetAction.MSC3869ReadRelations,
-                data: { event_id: '$event' },
-            };
-
-            emitEvent(new CustomEvent('', { detail: event }));
-
-            await waitFor(() => {
-                expect(transport.reply).toBeCalledWith(event, {
-                    error: { message: 'Cannot read state events of this type' },
-                });
             });
         });
 

--- a/test/WidgetApi-test.ts
+++ b/test/WidgetApi-test.ts
@@ -41,7 +41,6 @@ describe('WidgetApi', () => {
             );
             jest.mocked(PostmessageTransport.prototype.send).mockResolvedValue(
                 {
-                    original_event: undefined,
                     chunk: [],
                 } as IReadRelationsFromWidgetResponseData,
             );
@@ -50,7 +49,6 @@ describe('WidgetApi', () => {
                 '$event', '!room-id', 'm.reference', 'm.room.message', 25,
                 'from-token', 'to-token', 'f',
             )).resolves.toEqual({
-                original_event: undefined,
                 chunk: [],
             });
 


### PR DESCRIPTION
Relates to https://github.com/matrix-org/synapse/issues/12930

This removes the unspecced `original_event` field that will be removed from the Synapse soon. Since this API should work like the `/relations` endpoint of the CS-API, the field shouldn't be included here. I also removed the field from https://github.com/matrix-org/matrix-spec-proposals/pull/3869.

<!-- Please read https://github.com/matrix-org/matrix-widget-api/blob/master/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-widget-api/blob/master/CONTRIBUTING.md#sign-off -->
