### PR TITLE
Add missing null type in type declaration

### DIFF
--- a/src/driver/WidgetDriver.ts
+++ b/src/driver/WidgetDriver.ts
@@ -14,22 +14,29 @@
  * limitations under the License.
  */
 
-import { Capability, IOpenIDCredentials, OpenIDRequestState, SimpleObservable, IRoomEvent, ITurnServer } from "..";
+import {
+  Capability,
+  IOpenIDCredentials,
+  OpenIDRequestState,
+  SimpleObservable,
+  IRoomEvent,
+  ITurnServer,
+} from "..";
 
 export interface ISendEventDetails {
-    roomId: string;
-    eventId: string;
+  roomId: string;
+  eventId: string;
 }
 
 export interface IOpenIDUpdate {
-    state: OpenIDRequestState;
-    token?: IOpenIDCredentials;
+  state: OpenIDRequestState;
+  token?: IOpenIDCredentials;
 }
 
 export interface IReadEventRelationsResult {
-    chunk: IRoomEvent[];
-    nextBatch?: string;
-    prevBatch?: string;
+  chunk: IRoomEvent[];
+  nextBatch?: string;
+  prevBatch?: string;
 }
 
 /**
@@ -42,184 +49,186 @@ export interface IReadEventRelationsResult {
  * instance already.
  */
 export abstract class WidgetDriver {
-    /**
-     * Verifies the widget's requested capabilities, returning the ones
-     * it is approved to use. Mutating the requested capabilities will
-     * have no effect.
-     *
-     * This SHOULD result in the user being prompted to approve/deny
-     * capabilities.
-     *
-     * By default this rejects all capabilities (returns an empty set).
-     * @param {Set<Capability>} requested The set of requested capabilities.
-     * @returns {Promise<Set<Capability>>} Resolves to the allowed capabilities.
-     */
-    public validateCapabilities(requested: Set<Capability>): Promise<Set<Capability>> {
-        return Promise.resolve(new Set());
-    }
+  /**
+   * Verifies the widget's requested capabilities, returning the ones
+   * it is approved to use. Mutating the requested capabilities will
+   * have no effect.
+   *
+   * This SHOULD result in the user being prompted to approve/deny
+   * capabilities.
+   *
+   * By default this rejects all capabilities (returns an empty set).
+   * @param {Set<Capability>} requested The set of requested capabilities.
+   * @returns {Promise<Set<Capability>>} Resolves to the allowed capabilities.
+   */
+  public validateCapabilities(
+    requested: Set<Capability>
+  ): Promise<Set<Capability>> {
+    return Promise.resolve(new Set());
+  }
 
-    /**
-     * Sends an event into a room. If `roomId` is falsy, the client should send the event
-     * into the room the user is currently looking at. The widget API will have already
-     * verified that the widget is capable of sending the event to that room.
-     * @param {string} eventType The event type to be sent.
-     * @param {*} content The content for the event.
-     * @param {string|null} stateKey The state key if this is a state event, otherwise null.
-     * May be an empty string.
-     * @param {string|null} roomId The room ID to send the event to. If falsy, the room the
-     * user is currently looking at.
-     * @returns {Promise<ISendEventDetails>} Resolves when the event has been sent with
-     * details of that event.
-     * @throws Rejected when the event could not be sent.
-     */
-    public sendEvent(
-        eventType: string,
-        content: unknown,
-        stateKey: string = null,
-        roomId: string = null,
-    ): Promise<ISendEventDetails> {
-        return Promise.reject(new Error("Failed to override function"));
-    }
+  /**
+   * Sends an event into a room. If `roomId` is falsy, the client should send the event
+   * into the room the user is currently looking at. The widget API will have already
+   * verified that the widget is capable of sending the event to that room.
+   * @param {string} eventType The event type to be sent.
+   * @param {*} content The content for the event.
+   * @param {string|null} stateKey The state key if this is a state event, otherwise null.
+   * May be an empty string.
+   * @param {string|null} roomId The room ID to send the event to. If falsy, the room the
+   * user is currently looking at.
+   * @returns {Promise<ISendEventDetails>} Resolves when the event has been sent with
+   * details of that event.
+   * @throws Rejected when the event could not be sent.
+   */
+  public sendEvent(
+    eventType: string,
+    content: unknown,
+    stateKey: string | null = null,
+    roomId: string | null = null
+  ): Promise<ISendEventDetails> {
+    return Promise.reject(new Error("Failed to override function"));
+  }
 
-    /**
-     * Sends a to-device event. The widget API will have already verified that the widget
-     * is capable of sending the event.
-     * @param {string} eventType The event type to be sent.
-     * @param {boolean} encrypted Whether to encrypt the message contents.
-     * @param {Object} contentMap A map from user ID and device ID to event content.
-     * @returns {Promise<void>} Resolves when the event has been sent.
-     * @throws Rejected when the event could not be sent.
-     */
-    public sendToDevice(
-        eventType: string,
-        encrypted: boolean,
-        contentMap: { [userId: string]: { [deviceId: string]: object } },
-    ): Promise<void> {
-        return Promise.reject(new Error("Failed to override function"));
-    }
+  /**
+   * Sends a to-device event. The widget API will have already verified that the widget
+   * is capable of sending the event.
+   * @param {string} eventType The event type to be sent.
+   * @param {boolean} encrypted Whether to encrypt the message contents.
+   * @param {Object} contentMap A map from user ID and device ID to event content.
+   * @returns {Promise<void>} Resolves when the event has been sent.
+   * @throws Rejected when the event could not be sent.
+   */
+  public sendToDevice(
+    eventType: string,
+    encrypted: boolean,
+    contentMap: { [userId: string]: { [deviceId: string]: object } }
+  ): Promise<void> {
+    return Promise.reject(new Error("Failed to override function"));
+  }
 
-    /**
-     * Reads all events of the given type, and optionally `msgtype` (if applicable/defined),
-     * the user has access to. The widget API will have already verified that the widget is
-     * capable of receiving the events. Less events than the limit are allowed to be returned,
-     * but not more. If `roomIds` is supplied, it may contain `Symbols.AnyRoom` to denote that
-     * `limit` in each of the client's known rooms should be returned. When `null`, only the
-     * room the user is currently looking at should be considered.
-     * @param eventType The event type to be read.
-     * @param msgtype The msgtype of the events to be read, if applicable/defined.
-     * @param limit The maximum number of events to retrieve per room. Will be zero to denote "as many
-     * as possible".
-     * @param roomIds When null, the user's currently viewed room. Otherwise, the list of room IDs
-     * to look within, possibly containing Symbols.AnyRoom to denote all known rooms.
-     * @returns {Promise<IRoomEvent[]>} Resolves to the room events, or an empty array.
-     */
-    public readRoomEvents(
-        eventType: string,
-        msgtype: string | undefined,
-        limit: number,
-        roomIds: string[] = null,
-    ): Promise<IRoomEvent[]> {
-        return Promise.resolve([]);
-    }
+  /**
+   * Reads all events of the given type, and optionally `msgtype` (if applicable/defined),
+   * the user has access to. The widget API will have already verified that the widget is
+   * capable of receiving the events. Less events than the limit are allowed to be returned,
+   * but not more. If `roomIds` is supplied, it may contain `Symbols.AnyRoom` to denote that
+   * `limit` in each of the client's known rooms should be returned. When `null`, only the
+   * room the user is currently looking at should be considered.
+   * @param eventType The event type to be read.
+   * @param msgtype The msgtype of the events to be read, if applicable/defined.
+   * @param limit The maximum number of events to retrieve per room. Will be zero to denote "as many
+   * as possible".
+   * @param roomIds When null, the user's currently viewed room. Otherwise, the list of room IDs
+   * to look within, possibly containing Symbols.AnyRoom to denote all known rooms.
+   * @returns {Promise<IRoomEvent[]>} Resolves to the room events, or an empty array.
+   */
+  public readRoomEvents(
+    eventType: string,
+    msgtype: string | undefined,
+    limit: number,
+    roomIds: string[] = null
+  ): Promise<IRoomEvent[]> {
+    return Promise.resolve([]);
+  }
 
-    /**
-     * Reads all events of the given type, and optionally state key (if applicable/defined),
-     * the user has access to. The widget API will have already verified that the widget is
-     * capable of receiving the events. Less events than the limit are allowed to be returned,
-     * but not more. If `roomIds` is supplied, it may contain `Symbols.AnyRoom` to denote that
-     * `limit` in each of the client's known rooms should be returned. When `null`, only the
-     * room the user is currently looking at should be considered.
-     * @param eventType The event type to be read.
-     * @param stateKey The state key of the events to be read, if applicable/defined.
-     * @param limit The maximum number of events to retrieve. Will be zero to denote "as many
-     * as possible".
-     * @param roomIds When null, the user's currently viewed room. Otherwise, the list of room IDs
-     * to look within, possibly containing Symbols.AnyRoom to denote all known rooms.
-     * @returns {Promise<IRoomEvent[]>} Resolves to the state events, or an empty array.
-     */
-    public readStateEvents(
-        eventType: string,
-        stateKey: string | undefined,
-        limit: number,
-        roomIds: string[] = null,
-    ): Promise<IRoomEvent[]> {
-        return Promise.resolve([]);
-    }
+  /**
+   * Reads all events of the given type, and optionally state key (if applicable/defined),
+   * the user has access to. The widget API will have already verified that the widget is
+   * capable of receiving the events. Less events than the limit are allowed to be returned,
+   * but not more. If `roomIds` is supplied, it may contain `Symbols.AnyRoom` to denote that
+   * `limit` in each of the client's known rooms should be returned. When `null`, only the
+   * room the user is currently looking at should be considered.
+   * @param eventType The event type to be read.
+   * @param stateKey The state key of the events to be read, if applicable/defined.
+   * @param limit The maximum number of events to retrieve. Will be zero to denote "as many
+   * as possible".
+   * @param roomIds When null, the user's currently viewed room. Otherwise, the list of room IDs
+   * to look within, possibly containing Symbols.AnyRoom to denote all known rooms.
+   * @returns {Promise<IRoomEvent[]>} Resolves to the state events, or an empty array.
+   */
+  public readStateEvents(
+    eventType: string,
+    stateKey: string | undefined,
+    limit: number,
+    roomIds: string[] = null
+  ): Promise<IRoomEvent[]> {
+    return Promise.resolve([]);
+  }
 
-    /**
-     * Reads all events that are related to a given event. The widget API will
-     * have already verified that the widget is capable of receiving the event,
-     * or will make sure to reject access to events which are returned from this
-     * function, but are not capable of receiving. If `relationType` or `eventType`
-     * are set, the returned events should already be filtered. Less events than
-     * the limit are allowed to be returned, but not more.
-     * @param eventId The id of the parent event to be read.
-     * @param roomId The room to look within. When undefined, the user's
-     * currently viewed room.
-     * @param relationType The relationship type of child events to search for.
-     * When undefined, all relations are returned.
-     * @param eventType The event type of child events to search for. When undefined,
-     * all related events are returned.
-     * @param from The pagination token to start returning results from, as
-     * received from a previous call. If not supplied, results start at the most
-     * recent topological event known to the server.
-     * @param to The pagination token to stop returning results at. If not
-     * supplied, results continue up to limit or until there are no more events.
-     * @param limit The maximum number of events to retrieve per room. If not
-     * supplied, the server will apply a default limit.
-     * @param direction The direction to search for according to MSC3715
-     * @returns Resolves to the room relations.
-     */
-    public readEventRelations(
-        eventId: string,
-        roomId?: string,
-        relationType?: string,
-        eventType?: string,
-        from?: string,
-        to?: string,
-        limit?: number,
-        direction?: 'f' | 'b',
-    ): Promise<IReadEventRelationsResult> {
-        return Promise.resolve({ chunk: [] });
-    }
+  /**
+   * Reads all events that are related to a given event. The widget API will
+   * have already verified that the widget is capable of receiving the event,
+   * or will make sure to reject access to events which are returned from this
+   * function, but are not capable of receiving. If `relationType` or `eventType`
+   * are set, the returned events should already be filtered. Less events than
+   * the limit are allowed to be returned, but not more.
+   * @param eventId The id of the parent event to be read.
+   * @param roomId The room to look within. When undefined, the user's
+   * currently viewed room.
+   * @param relationType The relationship type of child events to search for.
+   * When undefined, all relations are returned.
+   * @param eventType The event type of child events to search for. When undefined,
+   * all related events are returned.
+   * @param from The pagination token to start returning results from, as
+   * received from a previous call. If not supplied, results start at the most
+   * recent topological event known to the server.
+   * @param to The pagination token to stop returning results at. If not
+   * supplied, results continue up to limit or until there are no more events.
+   * @param limit The maximum number of events to retrieve per room. If not
+   * supplied, the server will apply a default limit.
+   * @param direction The direction to search for according to MSC3715
+   * @returns Resolves to the room relations.
+   */
+  public readEventRelations(
+    eventId: string,
+    roomId?: string,
+    relationType?: string,
+    eventType?: string,
+    from?: string,
+    to?: string,
+    limit?: number,
+    direction?: "f" | "b"
+  ): Promise<IReadEventRelationsResult> {
+    return Promise.resolve({ chunk: [] });
+  }
 
-    /**
-     * Asks the user for permission to validate their identity through OpenID Connect. The
-     * interface for this function is an observable which accepts the state machine of the
-     * OIDC exchange flow. For example, if the client/user blocks the request then it would
-     * feed back a `{state: Blocked}` into the observable. Similarly, if the user already
-     * approved the widget then a `{state: Allowed}` would be fed into the observable alongside
-     * the token itself. If the client is asking for permission, it should feed in a
-     * `{state: PendingUserConfirmation}` followed by the relevant Allowed or Blocked state.
-     *
-     * The widget API will reject the widget's request with an error if this contract is not
-     * met properly. By default, the widget driver will block all OIDC requests.
-     * @param {SimpleObservable<IOpenIDUpdate>} observer The observable to feed updates into.
-     */
-    public askOpenID(observer: SimpleObservable<IOpenIDUpdate>) {
-        observer.update({state: OpenIDRequestState.Blocked});
-    }
+  /**
+   * Asks the user for permission to validate their identity through OpenID Connect. The
+   * interface for this function is an observable which accepts the state machine of the
+   * OIDC exchange flow. For example, if the client/user blocks the request then it would
+   * feed back a `{state: Blocked}` into the observable. Similarly, if the user already
+   * approved the widget then a `{state: Allowed}` would be fed into the observable alongside
+   * the token itself. If the client is asking for permission, it should feed in a
+   * `{state: PendingUserConfirmation}` followed by the relevant Allowed or Blocked state.
+   *
+   * The widget API will reject the widget's request with an error if this contract is not
+   * met properly. By default, the widget driver will block all OIDC requests.
+   * @param {SimpleObservable<IOpenIDUpdate>} observer The observable to feed updates into.
+   */
+  public askOpenID(observer: SimpleObservable<IOpenIDUpdate>) {
+    observer.update({ state: OpenIDRequestState.Blocked });
+  }
 
-    /**
-     * Navigates the client with a matrix.to URI. In future this function will also be provided
-     * with the Matrix URIs once matrix.to is replaced. The given URI will have already been
-     * lightly checked to ensure it looks like a valid URI, though the implementation is recommended
-     * to do further checks on the URI.
-     * @param {string} uri The URI to navigate to.
-     * @returns {Promise<void>} Resolves when complete.
-     * @throws Throws if there's a problem with the navigation, such as invalid format.
-     */
-    public navigate(uri: string): Promise<void> {
-        throw new Error("Navigation is not implemented");
-    }
+  /**
+   * Navigates the client with a matrix.to URI. In future this function will also be provided
+   * with the Matrix URIs once matrix.to is replaced. The given URI will have already been
+   * lightly checked to ensure it looks like a valid URI, though the implementation is recommended
+   * to do further checks on the URI.
+   * @param {string} uri The URI to navigate to.
+   * @returns {Promise<void>} Resolves when complete.
+   * @throws Throws if there's a problem with the navigation, such as invalid format.
+   */
+  public navigate(uri: string): Promise<void> {
+    throw new Error("Navigation is not implemented");
+  }
 
-    /**
-     * Polls for TURN server data, yielding an initial set of credentials as soon as possible, and
-     * thereafter yielding new credentials whenever the previous ones expire. The widget API will
-     * have already verified that the widget has permission to access TURN servers.
-     * @yields {ITurnServer} The TURN server URIs and credentials currently available to the client.
-     */
-    public getTurnServers(): AsyncGenerator<ITurnServer> {
-        throw new Error("TURN server support is not implemented");
-    }
+  /**
+   * Polls for TURN server data, yielding an initial set of credentials as soon as possible, and
+   * thereafter yielding new credentials whenever the previous ones expire. The widget API will
+   * have already verified that the widget has permission to access TURN servers.
+   * @yields {ITurnServer} The TURN server URIs and credentials currently available to the client.
+   */
+  public getTurnServers(): AsyncGenerator<ITurnServer> {
+    throw new Error("TURN server support is not implemented");
+  }
 }

--- a/src/models/WidgetEventCapability.ts
+++ b/src/models/WidgetEventCapability.ts
@@ -17,188 +17,224 @@
 import { Capability } from "..";
 
 export enum EventKind {
-    Event = "event",
-    State = "state_event",
-    ToDevice = "to_device",
+  Event = "event",
+  State = "state_event",
+  ToDevice = "to_device",
 }
 
 export enum EventDirection {
-    Send = "send",
-    Receive = "receive",
+  Send = "send",
+  Receive = "receive",
 }
 
 export class WidgetEventCapability {
-    private constructor(
-        public readonly direction: EventDirection,
-        public readonly eventType: string,
-        public readonly kind: EventKind,
-        public readonly keyStr: string | null,
-        public readonly raw: string,
-    ) {
+  private constructor(
+    public readonly direction: EventDirection,
+    public readonly eventType: string,
+    public readonly kind: EventKind,
+    public readonly keyStr: string | null,
+    public readonly raw: string
+  ) {}
+
+  public matchesAsStateEvent(
+    direction: EventDirection,
+    eventType: string,
+    stateKey: string
+  ): boolean {
+    if (this.kind !== EventKind.State) return false; // not a state event
+    if (this.direction !== direction) return false; // direction mismatch
+    if (this.eventType !== eventType) return false; // event type mismatch
+    if (this.keyStr === null) return true; // all state keys are allowed
+    if (this.keyStr === stateKey) return true; // this state key is allowed
+
+    // Default not allowed
+    return false;
+  }
+
+  public matchesAsToDeviceEvent(
+    direction: EventDirection,
+    eventType: string
+  ): boolean {
+    if (this.kind !== EventKind.ToDevice) return false; // not a to-device event
+    if (this.direction !== direction) return false; // direction mismatch
+    if (this.eventType !== eventType) return false; // event type mismatch
+
+    // Checks passed, the event is allowed
+    return true;
+  }
+
+  public matchesAsRoomEvent(
+    direction: EventDirection,
+    eventType: string,
+    msgtype: string = null
+  ): boolean {
+    if (this.kind !== EventKind.Event) return false; // not a room event
+    if (this.direction !== direction) return false; // direction mismatch
+    if (this.eventType !== eventType) return false; // event type mismatch
+
+    if (this.eventType === "m.room.message") {
+      if (this.keyStr === null) return true; // all message types are allowed
+      if (this.keyStr === msgtype) return true; // this message type is allowed
+    } else {
+      return true; // already passed the check for if the event is allowed
     }
 
-    public matchesAsStateEvent(direction: EventDirection, eventType: string, stateKey: string): boolean {
-        if (this.kind !== EventKind.State) return false; // not a state event
-        if (this.direction !== direction) return false; // direction mismatch
-        if (this.eventType !== eventType) return false; // event type mismatch
-        if (this.keyStr === null) return true; // all state keys are allowed
-        if (this.keyStr === stateKey) return true; // this state key is allowed
+    // Default not allowed
+    return false;
+  }
 
-        // Default not allowed
-        return false;
+  public static forStateEvent(
+    direction: EventDirection,
+    eventType: string,
+    stateKey?: string | null | undefined
+  ): WidgetEventCapability {
+    // TODO: Enable support for m.* namespace once the MSC lands.
+    // https://github.com/matrix-org/matrix-widget-api/issues/22
+    eventType = eventType.replace(/#/g, "\\#");
+    stateKey =
+      stateKey !== null && stateKey !== undefined ? `#${stateKey}` : "";
+    const str = `org.matrix.msc2762.${direction}.state_event:${eventType}${stateKey}`;
+
+    // cheat by sending it through the processor
+    return WidgetEventCapability.findEventCapabilities([str])[0];
+  }
+
+  public static forToDeviceEvent(
+    direction: EventDirection,
+    eventType: string
+  ): WidgetEventCapability {
+    // TODO: Enable support for m.* namespace once the MSC lands.
+    // https://github.com/matrix-org/matrix-widget-api/issues/56
+    const str = `org.matrix.msc3819.${direction}.to_device:${eventType}`;
+
+    // cheat by sending it through the processor
+    return WidgetEventCapability.findEventCapabilities([str])[0];
+  }
+
+  public static forRoomEvent(
+    direction: EventDirection,
+    eventType: string
+  ): WidgetEventCapability {
+    // TODO: Enable support for m.* namespace once the MSC lands.
+    // https://github.com/matrix-org/matrix-widget-api/issues/22
+    const str = `org.matrix.msc2762.${direction}.event:${eventType}`;
+
+    // cheat by sending it through the processor
+    return WidgetEventCapability.findEventCapabilities([str])[0];
+  }
+
+  public static forRoomMessageEvent(
+    direction: EventDirection,
+    msgtype?: string
+  ): WidgetEventCapability {
+    // TODO: Enable support for m.* namespace once the MSC lands.
+    // https://github.com/matrix-org/matrix-widget-api/issues/22
+    msgtype = msgtype === null || msgtype === undefined ? "" : msgtype;
+    const str = `org.matrix.msc2762.${direction}.event:m.room.message#${msgtype}`;
+
+    // cheat by sending it through the processor
+    return WidgetEventCapability.findEventCapabilities([str])[0];
+  }
+
+  /**
+   * Parses a capabilities request to find all the event capability requests.
+   * @param {Iterable<Capability>} capabilities The capabilities requested/to parse.
+   * @returns {WidgetEventCapability[]} An array of event capability requests. May be empty, but never null.
+   */
+  public static findEventCapabilities(
+    capabilities: Iterable<Capability>
+  ): WidgetEventCapability[] {
+    const parsed: WidgetEventCapability[] = [];
+    for (const cap of capabilities) {
+      let direction: EventDirection = null;
+      let eventSegment: string;
+      let kind: EventKind = null;
+
+      // TODO: Enable support for m.* namespace once the MSCs land.
+      // https://github.com/matrix-org/matrix-widget-api/issues/22
+      // https://github.com/matrix-org/matrix-widget-api/issues/56
+
+      if (cap.startsWith("org.matrix.msc2762.send.event:")) {
+        direction = EventDirection.Send;
+        kind = EventKind.Event;
+        eventSegment = cap.substring("org.matrix.msc2762.send.event:".length);
+      } else if (cap.startsWith("org.matrix.msc2762.send.state_event:")) {
+        direction = EventDirection.Send;
+        kind = EventKind.State;
+        eventSegment = cap.substring(
+          "org.matrix.msc2762.send.state_event:".length
+        );
+      } else if (cap.startsWith("org.matrix.msc3819.send.to_device:")) {
+        direction = EventDirection.Send;
+        kind = EventKind.ToDevice;
+        eventSegment = cap.substring(
+          "org.matrix.msc3819.send.to_device:".length
+        );
+      } else if (cap.startsWith("org.matrix.msc2762.receive.event:")) {
+        direction = EventDirection.Receive;
+        kind = EventKind.Event;
+        eventSegment = cap.substring(
+          "org.matrix.msc2762.receive.event:".length
+        );
+      } else if (cap.startsWith("org.matrix.msc2762.receive.state_event:")) {
+        direction = EventDirection.Receive;
+        kind = EventKind.State;
+        eventSegment = cap.substring(
+          "org.matrix.msc2762.receive.state_event:".length
+        );
+      } else if (cap.startsWith("org.matrix.msc3819.receive.to_device:")) {
+        direction = EventDirection.Receive;
+        kind = EventKind.ToDevice;
+        eventSegment = cap.substring(
+          "org.matrix.msc3819.receive.to_device:".length
+        );
+      }
+
+      if (direction === null || kind === null) continue;
+
+      // The capability uses `#` as a separator between event type and state key/msgtype,
+      // so we split on that. However, a # is also valid in either one of those so we
+      // join accordingly.
+      // Eg: `m.room.message##m.text` is "m.room.message" event with msgtype "#m.text".
+      const expectingKeyStr =
+        eventSegment.startsWith("m.room.message#") || kind === EventKind.State;
+      let keyStr: string = null;
+      if (eventSegment.includes("#") && expectingKeyStr) {
+        // Dev note: regex is difficult to write, so instead the rules are manually written
+        // out. This is probably just as understandable as a boring regex though, so win-win?
+
+        // Test cases:
+        // str                      eventSegment        keyStr
+        // -------------------------------------------------------------
+        // m.room.message#          m.room.message      <empty string>
+        // m.room.message#test      m.room.message      test
+        // m.room.message\#         m.room.message#     test
+        // m.room.message##test     m.room.message      #test
+        // m.room.message\##test    m.room.message#     test
+        // m.room.message\\##test   m.room.message\#    test
+        // m.room.message\\###test  m.room.message\#    #test
+
+        // First step: explode the string
+        const parts = eventSegment.split("#");
+
+        // To form the eventSegment, we'll keep finding parts of the exploded string until
+        // there's one that doesn't end with the escape character (\). We'll then join those
+        // segments together with the exploding character. We have to remember to consume the
+        // escape character as well.
+        const idx = parts.findIndex((p) => !p.endsWith("\\"));
+        eventSegment = parts
+          .slice(0, idx + 1)
+          .map((p) => (p.endsWith("\\") ? p.substring(0, p.length - 1) : p))
+          .join("#");
+
+        // The keyStr is whatever is left over.
+        keyStr = parts.slice(idx + 1).join("#");
+      }
+
+      parsed.push(
+        new WidgetEventCapability(direction, eventSegment, kind, keyStr, cap)
+      );
     }
-
-    public matchesAsToDeviceEvent(direction: EventDirection, eventType: string): boolean {
-        if (this.kind !== EventKind.ToDevice) return false; // not a to-device event
-        if (this.direction !== direction) return false; // direction mismatch
-        if (this.eventType !== eventType) return false; // event type mismatch
-
-        // Checks passed, the event is allowed
-        return true;
-    }
-
-    public matchesAsRoomEvent(direction: EventDirection, eventType: string, msgtype: string = null): boolean {
-        if (this.kind !== EventKind.Event) return false; // not a room event
-        if (this.direction !== direction) return false; // direction mismatch
-        if (this.eventType !== eventType) return false; // event type mismatch
-
-        if (this.eventType === "m.room.message") {
-            if (this.keyStr === null) return true; // all message types are allowed
-            if (this.keyStr === msgtype) return true; // this message type is allowed
-        } else {
-            return true; // already passed the check for if the event is allowed
-        }
-
-        // Default not allowed
-        return false;
-    }
-
-    public static forStateEvent(
-        direction: EventDirection,
-        eventType: string,
-        stateKey?: string,
-    ): WidgetEventCapability {
-        // TODO: Enable support for m.* namespace once the MSC lands.
-        // https://github.com/matrix-org/matrix-widget-api/issues/22
-        eventType = eventType.replace(/#/g, '\\#');
-        stateKey = stateKey !== null && stateKey !== undefined ? `#${stateKey}` : '';
-        const str = `org.matrix.msc2762.${direction}.state_event:${eventType}${stateKey}`;
-
-        // cheat by sending it through the processor
-        return WidgetEventCapability.findEventCapabilities([str])[0];
-    }
-
-    public static forToDeviceEvent(direction: EventDirection, eventType: string): WidgetEventCapability {
-        // TODO: Enable support for m.* namespace once the MSC lands.
-        // https://github.com/matrix-org/matrix-widget-api/issues/56
-        const str = `org.matrix.msc3819.${direction}.to_device:${eventType}`;
-
-        // cheat by sending it through the processor
-        return WidgetEventCapability.findEventCapabilities([str])[0];
-    }
-
-    public static forRoomEvent(direction: EventDirection, eventType: string): WidgetEventCapability {
-        // TODO: Enable support for m.* namespace once the MSC lands.
-        // https://github.com/matrix-org/matrix-widget-api/issues/22
-        const str = `org.matrix.msc2762.${direction}.event:${eventType}`;
-
-        // cheat by sending it through the processor
-        return WidgetEventCapability.findEventCapabilities([str])[0];
-    }
-
-    public static forRoomMessageEvent(direction: EventDirection, msgtype?: string): WidgetEventCapability {
-        // TODO: Enable support for m.* namespace once the MSC lands.
-        // https://github.com/matrix-org/matrix-widget-api/issues/22
-        msgtype = msgtype === null || msgtype === undefined ? '' : msgtype;
-        const str = `org.matrix.msc2762.${direction}.event:m.room.message#${msgtype}`;
-
-        // cheat by sending it through the processor
-        return WidgetEventCapability.findEventCapabilities([str])[0];
-    }
-
-    /**
-     * Parses a capabilities request to find all the event capability requests.
-     * @param {Iterable<Capability>} capabilities The capabilities requested/to parse.
-     * @returns {WidgetEventCapability[]} An array of event capability requests. May be empty, but never null.
-     */
-    public static findEventCapabilities(capabilities: Iterable<Capability>): WidgetEventCapability[] {
-        const parsed: WidgetEventCapability[] = [];
-        for (const cap of capabilities) {
-            let direction: EventDirection = null;
-            let eventSegment: string;
-            let kind: EventKind = null;
-
-            // TODO: Enable support for m.* namespace once the MSCs land.
-            // https://github.com/matrix-org/matrix-widget-api/issues/22
-            // https://github.com/matrix-org/matrix-widget-api/issues/56
-
-            if (cap.startsWith("org.matrix.msc2762.send.event:")) {
-                direction = EventDirection.Send;
-                kind = EventKind.Event;
-                eventSegment = cap.substring("org.matrix.msc2762.send.event:".length);
-            } else if (cap.startsWith("org.matrix.msc2762.send.state_event:")) {
-                direction = EventDirection.Send;
-                kind = EventKind.State;
-                eventSegment = cap.substring("org.matrix.msc2762.send.state_event:".length);
-            } else if (cap.startsWith("org.matrix.msc3819.send.to_device:")) {
-                direction = EventDirection.Send;
-                kind = EventKind.ToDevice;
-                eventSegment = cap.substring("org.matrix.msc3819.send.to_device:".length);
-            } else if (cap.startsWith("org.matrix.msc2762.receive.event:")) {
-                direction = EventDirection.Receive;
-                kind = EventKind.Event;
-                eventSegment = cap.substring("org.matrix.msc2762.receive.event:".length);
-            } else if (cap.startsWith("org.matrix.msc2762.receive.state_event:")) {
-                direction = EventDirection.Receive;
-                kind = EventKind.State;
-                eventSegment = cap.substring("org.matrix.msc2762.receive.state_event:".length);
-            } else if (cap.startsWith("org.matrix.msc3819.receive.to_device:")) {
-                direction = EventDirection.Receive;
-                kind = EventKind.ToDevice;
-                eventSegment = cap.substring("org.matrix.msc3819.receive.to_device:".length);
-            }
-
-            if (direction === null || kind === null) continue;
-
-            // The capability uses `#` as a separator between event type and state key/msgtype,
-            // so we split on that. However, a # is also valid in either one of those so we
-            // join accordingly.
-            // Eg: `m.room.message##m.text` is "m.room.message" event with msgtype "#m.text".
-            const expectingKeyStr = eventSegment.startsWith("m.room.message#") || kind === EventKind.State;
-            let keyStr: string = null;
-            if (eventSegment.includes('#') && expectingKeyStr) {
-                // Dev note: regex is difficult to write, so instead the rules are manually written
-                // out. This is probably just as understandable as a boring regex though, so win-win?
-
-                // Test cases:
-                // str                      eventSegment        keyStr
-                // -------------------------------------------------------------
-                // m.room.message#          m.room.message      <empty string>
-                // m.room.message#test      m.room.message      test
-                // m.room.message\#         m.room.message#     test
-                // m.room.message##test     m.room.message      #test
-                // m.room.message\##test    m.room.message#     test
-                // m.room.message\\##test   m.room.message\#    test
-                // m.room.message\\###test  m.room.message\#    #test
-
-                // First step: explode the string
-                const parts = eventSegment.split('#');
-
-                // To form the eventSegment, we'll keep finding parts of the exploded string until
-                // there's one that doesn't end with the escape character (\). We'll then join those
-                // segments together with the exploding character. We have to remember to consume the
-                // escape character as well.
-                const idx = parts.findIndex(p => !p.endsWith("\\"));
-                eventSegment = parts.slice(0, idx + 1)
-                    .map(p => p.endsWith('\\') ? p.substring(0, p.length - 1) : p)
-                    .join('#');
-
-                // The keyStr is whatever is left over.
-                keyStr = parts.slice(idx + 1).join('#');
-            }
-
-            parsed.push(new WidgetEventCapability(direction, eventSegment, kind, keyStr, cap));
-        }
-        return parsed;
-    }
+    return parsed;
+  }
 }


### PR DESCRIPTION
The exported type declaration ends up being 

```
    sendEvent(eventType: string, content: unknown, stateKey?: string, roomId?: string): Promise<ISendEventDetails>;
```

which does not match the usage, where the code is checking for `null`

<!-- Please read https://github.com/matrix-org/matrix-widget-api/blob/master/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-widget-api/blob/master/CONTRIBUTING.md#sign-off -->
