### PR TITLE
Extend url template variables with device_id

### DIFF
--- a/src/templating/url-template.ts
+++ b/src/templating/url-template.ts
@@ -24,6 +24,7 @@ export interface ITemplateParams {
     clientId?: string;
     clientTheme?: string;
     clientLanguage?: string;
+    deviceId?: string;
 }
 
 export function runTemplate(url: string, widget: IWidget, params: ITemplateParams): string {
@@ -39,6 +40,9 @@ export function runTemplate(url: string, widget: IWidget, params: ITemplateParam
         'org.matrix.msc2873.client_id': params.clientId || "",
         'org.matrix.msc2873.client_theme': params.clientTheme || "",
         'org.matrix.msc2873.client_language': params.clientLanguage || "",
+
+        // TODO: Convert to stable (https://github.com/matrix-org/matrix-spec-proposals/pull/3819)
+        'org.matrix.msc3819.device_id': params.deviceId || "",
     });
     let result = url;
     for (const key of Object.keys(variables)) {

--- a/src/templating/url-template.ts
+++ b/src/templating/url-template.ts
@@ -42,7 +42,7 @@ export function runTemplate(url: string, widget: IWidget, params: ITemplateParam
         'org.matrix.msc2873.client_language': params.clientLanguage || "",
 
         // TODO: Convert to stable (https://github.com/matrix-org/matrix-spec-proposals/pull/3819)
-        'org.matrix.msc3819.device_id': params.deviceId || "",
+        'org.matrix.msc3819.matrix_device_id': params.deviceId || "",
     });
     let result = url;
     for (const key of Object.keys(variables)) {

--- a/test/url-template-test.ts
+++ b/test/url-template-test.ts
@@ -18,7 +18,7 @@ import { runTemplate } from "../src";
 
 describe("runTemplate", () => {
     it("should replace device id template in url", () => {
-        const url = "https://localhost/?my-query#device_id=$org.matrix.msc3819.device_id";
+        const url = "https://localhost/?my-query#device_id=$org.matrix.msc3819.matrix_device_id";
         const replacedUrl = runTemplate(
             url,
             {

--- a/test/url-template-test.ts
+++ b/test/url-template-test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 Nordeck IT + Consulting GmbH.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { runTemplate } from "../src";
+
+describe("runTemplate", () => {
+    it("should replace device id template in url", () => {
+        const url = "https://localhost/?my-query#device_id=$org.matrix.msc3819.device_id";
+        const replacedUrl = runTemplate(
+            url,
+            {
+                id: "widget-id",
+                creatorUserId: '@user-id',
+                type: 'type',
+                url,
+            },
+            {
+                deviceId: "my-device-id",
+                currentUserId: '@user-id',
+            },
+        );
+
+        expect(replacedUrl).toBe("https://localhost/?my-query#device_id=my-device-id");
+    });
+});


### PR DESCRIPTION
I mentioned the need for this parameter in the related [MSC 3891 ](https://github.com/matrix-org/matrix-spec-proposals/pull/3819) which implements to device messages. They are relying on the device id to be available, but there is currently no way to access a device id from within a widget (Element Call does this but is cheating :P). Therefore [I propose to include the device id in the available parameters](https://github.com/matrix-org/matrix-spec-proposals/pull/3819#discussion_r1099833846).

<!-- Please read https://github.com/matrix-org/matrix-widget-api/blob/master/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-widget-api/blob/master/CONTRIBUTING.md#sign-off -->
