### PR TITLE
Fix reading state events without a specific state key

### DIFF
--- a/src/ClientWidgetApi.ts
+++ b/src/ClientWidgetApi.ts
@@ -178,7 +178,7 @@ export class ClientWidgetApi extends EventEmitter {
         return this.allowedEvents.some(e => e.matchesAsRoomEvent(EventDirection.Receive, eventType, msgtype));
     }
 
-    public canReceiveStateEvent(eventType: string, stateKey: string): boolean {
+    public canReceiveStateEvent(eventType: string, stateKey: string | null): boolean {
         return this.allowedEvents.some(e => e.matchesAsStateEvent(EventDirection.Receive, eventType, stateKey));
     }
 
@@ -401,7 +401,7 @@ export class ClientWidgetApi extends EventEmitter {
         let events: Promise<IRoomEvent[]> = Promise.resolve([]);
         if (request.data.state_key !== undefined) {
             const stateKey = request.data.state_key === true ? undefined : request.data.state_key.toString();
-            if (!stateKey || !this.canReceiveStateEvent(request.data.type, stateKey)) {
+            if (!this.canReceiveStateEvent(request.data.type, stateKey ?? null)) {
                 return this.transport.reply<IWidgetApiErrorResponseData>(request, {
                     error: {message: "Cannot read state events of this type"},
                 });

--- a/src/models/WidgetEventCapability.ts
+++ b/src/models/WidgetEventCapability.ts
@@ -37,7 +37,7 @@ export class WidgetEventCapability {
     ) {
     }
 
-    public matchesAsStateEvent(direction: EventDirection, eventType: string, stateKey: string): boolean {
+    public matchesAsStateEvent(direction: EventDirection, eventType: string, stateKey: string | null): boolean {
         if (this.kind !== EventKind.State) return false; // not a state event
         if (this.direction !== direction) return false; // direction mismatch
         if (this.eventType !== eventType) return false; // event type mismatch


### PR DESCRIPTION
And add some tests for reading state events while we're at it.

For https://github.com/vector-im/element-web/issues/24858

Regressed by a8fc2b929564fac88d0bf0e6f175c8299190871e