### PR TITLE
Add a warning if contentLoaded event isn't received

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "matrix-widget-api",
   "version": "1.4.0",
   "description": "Matrix Widget API SDK",
-  "main": "./lib/index.js",
+  "main": "./src/index.ts",
   "types": "./lib/index.d.ts",
   "repository": "https://github.com/matrix-org/matrix-widget-api",
   "author": "The Matrix.org Foundation C.I.C.",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "matrix-widget-api",
   "version": "1.4.0",
   "description": "Matrix Widget API SDK",
-  "main": "./src/index.ts",
+  "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "repository": "https://github.com/matrix-org/matrix-widget-api",
   "author": "The Matrix.org Foundation C.I.C.",


### PR DESCRIPTION
So the widget fails less silently if waitForIFrameLoad=false is specified but the widget doesn't send the contentLoaded event, to help prevent people like me being daft and wasting ages because they reverted one bit of code and not the other.

Also fixes a couple of typos.

<!-- Please read https://github.com/matrix-org/matrix-widget-api/blob/master/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-widget-api/blob/master/CONTRIBUTING.md#sign-off -->
