### PR TITLE
Explicitly build lib during release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,6 +40,9 @@ jobs:
           git commit -am "${{ github.event.inputs.version-bump }} version bump"
           git push
 
+      - name: 📖 Build lib
+        run: yarn build
+
       - name: 🚀 Publish to npm
         id: npm-publish
         uses: JS-DevTools/npm-publish@v3

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "author": "The Matrix.org Foundation C.I.C.",
   "license": "Apache-2.0",
   "scripts": {
-    "prepublishOnly": "yarn build",
     "start": "tsc -w",
     "clean": "rimraf lib dist",
     "build": "yarn clean && yarn build:compile && yarn build:types && yarn build:browser",


### PR DESCRIPTION
Also remove the `prepublishOnly` script, as it is no longer supported by newer Yarn versions, and isn't needed for the release workflow anyhow.

Fixes #95 

Signed-off-by: Andrew Ferrazzutti <andrewf@element.io>