### PR TITLE
Implement download_file action

### DIFF
--- a/src/WidgetApi.ts
+++ b/src/WidgetApi.ts
@@ -90,6 +90,10 @@ import {
     IUpdateDelayedEventFromWidgetResponseData,
     UpdateDelayedEventAction,
 } from "./interfaces/UpdateDelayedEventAction";
+import {
+    IDownloadFileActionFromWidgetRequestData,
+    IDownloadFileActionFromWidgetResponseData,
+} from "./interfaces/DownloadFileAction";
 
 /**
  * API handler for widgets. This raises events for each action
@@ -748,6 +752,27 @@ export class WidgetApi extends EventEmitter {
             IUploadFileActionFromWidgetRequestData,
             IUploadFileActionFromWidgetResponseData
         >(WidgetApiFromWidgetAction.MSC4039UploadFileAction, data);
+    }
+
+    /**
+     * Download a file from the media repository on the homeserver.
+     * @param contentUri - MXC of the file to download.
+     * @returns Resolves to the contents of the file.
+     */
+    public async downloadFile(contentUri: string): Promise<IDownloadFileActionFromWidgetResponseData> {
+        const versions = await this.getClientVersions();
+        if (!versions.includes(UnstableApiVersion.MSC4039)) {
+            throw new Error("The download_file action is not supported by the client.")
+        }
+
+        const data: IDownloadFileActionFromWidgetRequestData = {
+            content_uri: contentUri,
+        };
+
+        return this.transport.send<
+            IDownloadFileActionFromWidgetRequestData,
+            IDownloadFileActionFromWidgetResponseData
+        >(WidgetApiFromWidgetAction.MSC4039DownloadFileAction, data);
     }
 
     /**

--- a/src/driver/WidgetDriver.ts
+++ b/src/driver/WidgetDriver.ts
@@ -347,4 +347,15 @@ export abstract class WidgetDriver {
     ): Promise<{ contentUri: string }> {
         throw new Error("Upload file is not implemented");
     }
+
+    /**
+     * Download a file from the media repository on the homeserver.
+     * @param contentUri - MXC of the file to download.
+     * @returns Resolves to the contents of the file.
+     */
+    public downloadFile(
+        contentUri: string,
+    ): Promise<{ file: XMLHttpRequestBodyInit }> {
+        throw new Error("Download file is not implemented");
+    }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,7 @@ export * from "./interfaces/ReadRelationsAction";
 export * from "./interfaces/GetMediaConfigAction";
 export * from "./interfaces/UpdateDelayedEventAction";
 export * from "./interfaces/UploadFileAction";
+export * from "./interfaces/DownloadFileAction";
 
 // Complex models
 export * from "./models/WidgetEventCapability";

--- a/src/interfaces/Capabilities.ts
+++ b/src/interfaces/Capabilities.ts
@@ -41,6 +41,10 @@ export enum MatrixCapabilities {
     /**
     * @deprecated It is not recommended to rely on this existing - it can be removed without notice.
     */
+    MSC4039DownloadFile = "org.matrix.msc4039.download_file",
+    /**
+    * @deprecated It is not recommended to rely on this existing - it can be removed without notice.
+    */
     MSC4157SendDelayedEvent = "org.matrix.msc4157.send.delayed_event",
     /**
     * @deprecated It is not recommended to rely on this existing - it can be removed without notice.

--- a/src/interfaces/DownloadFileAction.ts
+++ b/src/interfaces/DownloadFileAction.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { IWidgetApiRequest, IWidgetApiRequestData } from "./IWidgetApiRequest";
+import { IWidgetApiResponseData } from "./IWidgetApiResponse";
+import { WidgetApiFromWidgetAction } from "./WidgetApiAction";
+
+export interface IDownloadFileActionFromWidgetRequestData
+  extends IWidgetApiRequestData {
+  content_uri: string;  // eslint-disable-line camelcase
+}
+
+export interface IDownloadFileActionFromWidgetActionRequest
+  extends IWidgetApiRequest {
+  action: WidgetApiFromWidgetAction.MSC4039DownloadFileAction;
+  data: IDownloadFileActionFromWidgetRequestData;
+}
+
+export interface IDownloadFileActionFromWidgetResponseData
+  extends IWidgetApiResponseData {
+  file: XMLHttpRequestBodyInit;
+}
+
+export interface IDownloadFileActionFromWidgetActionResponse
+  extends IDownloadFileActionFromWidgetActionRequest {
+  response: IDownloadFileActionFromWidgetResponseData;
+}

--- a/src/interfaces/WidgetApiAction.ts
+++ b/src/interfaces/WidgetApiAction.ts
@@ -83,6 +83,11 @@ export enum WidgetApiFromWidgetAction {
     /**
      * @deprecated It is not recommended to rely on this existing - it can be removed without notice.
      */
+    MSC4039DownloadFileAction = "org.matrix.msc4039.download_file",
+
+    /**
+     * @deprecated It is not recommended to rely on this existing - it can be removed without notice.
+     */
     MSC4157UpdateDelayedEvent = "org.matrix.msc4157.update_delayed_event",
 }
 


### PR DESCRIPTION
Adds support for the `download_file` action according to [`MSC4039`](https://github.com/matrix-org/matrix-spec-proposals/pull/4039).

It contains neither the timeout nor the encryption part. This can be done in subsequent PRs.