### PR TITLE
Pass HTTP status code & errcode from CS-API errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,6 +31,9 @@ module.exports = {
         "files": ["src/**/*.ts", "test/**/*.ts"],
         "extends": ["matrix-org/ts"],
         "rules": {
+            // TypeScript has its own version of this
+            "babel/no-invalid-this": "off",
+
             "quotes": "off",
         },
     }],

--- a/src/ClientWidgetApi.ts
+++ b/src/ClientWidgetApi.ts
@@ -833,11 +833,11 @@ export class ClientWidgetApi extends EventEmitter {
     }
 
     private handleDriverError(e: unknown, request: IWidgetApiRequest, message: string) {
-        const matrixApiError = this.driver.processError(e);
+        const errorDetails = this.driver.processError(e);
         this.transport.reply<IWidgetApiErrorResponseData>(request, {
             error: {
                 message,
-                ...(matrixApiError && { matrix_api_error: { ...matrixApiError } }),
+                ...errorDetails,
             },
         });
     }

--- a/src/ClientWidgetApi.ts
+++ b/src/ClientWidgetApi.ts
@@ -22,7 +22,7 @@ import { WidgetApiDirection } from "./interfaces/WidgetApiDirection";
 import { IWidgetApiRequest, IWidgetApiRequestEmptyData } from "./interfaces/IWidgetApiRequest";
 import { IContentLoadedActionRequest } from "./interfaces/ContentLoadedAction";
 import { WidgetApiFromWidgetAction, WidgetApiToWidgetAction } from "./interfaces/WidgetApiAction";
-import { IWidgetApiErrorResponseData } from "./interfaces/IWidgetApiErrorResponse";
+import { IWidgetApiErrorResponseData, isMatrixError } from "./interfaces/IWidgetApiErrorResponse";
 import { Capability, MatrixCapabilities } from "./interfaces/Capabilities";
 import { IOpenIDUpdate, ISendEventDetails, ISendDelayedEventDetails, WidgetDriver } from "./driver/WidgetDriver";
 import {
@@ -554,10 +554,13 @@ export class ClientWidgetApi extends EventEmitter {
                     delay_id: sentEvent.delayId,
                 }),
             });
-        }).catch(e => {
+        }).catch((e: unknown) => {
             console.error("error sending event: ", e);
             return this.transport.reply<IWidgetApiErrorResponseData>(request, {
-                error: {message: "Error sending event"},
+                error: {
+                    message: "Error sending event",
+                    ...(isMatrixError(e) && e),
+                },
             });
         });
     }
@@ -581,10 +584,13 @@ export class ClientWidgetApi extends EventEmitter {
             case UpdateDelayedEventAction.Send:
                 this.driver.updateDelayedEvent(request.data.delay_id, request.data.action).then(() => {
                     return this.transport.reply<IWidgetApiAcknowledgeResponseData>(request, {});
-                }).catch(e => {
+                }).catch((e: unknown) => {
                     console.error("error updating delayed event: ", e);
                     return this.transport.reply<IWidgetApiErrorResponseData>(request, {
-                        error: {message: "Error updating delayed event"},
+                        error: {
+                            message: "Error updating delayed event",
+                            ...(isMatrixError(e) && e),
+                        },
                     });
                 });
                 break;
@@ -736,7 +742,10 @@ export class ClientWidgetApi extends EventEmitter {
         } catch (e) {
             console.error("error getting the relations", e);
             await this.transport.reply<IWidgetApiErrorResponseData>(request, {
-                error: { message: "Unexpected error while reading relations" },
+                error: {
+                    message: "Unexpected error while reading relations",
+                    ...(isMatrixError(e) && e),
+                },
             });
         }
     }
@@ -779,7 +788,10 @@ export class ClientWidgetApi extends EventEmitter {
         } catch (e) {
             console.error("error searching in the user directory", e);
             await this.transport.reply<IWidgetApiErrorResponseData>(request, {
-                error: { message: "Unexpected error while searching in the user directory" },
+                error: {
+                    message: "Unexpected error while searching in the user directory",
+                    ...(isMatrixError(e) && e),
+                },
             });
         }
     }
@@ -801,7 +813,10 @@ export class ClientWidgetApi extends EventEmitter {
         } catch (e) {
             console.error("error while getting the media configuration", e);
             await this.transport.reply<IWidgetApiErrorResponseData>(request, {
-                error: { message: "Unexpected error while getting the media configuration" },
+                error: {
+                    message: "Unexpected error while getting the media configuration",
+                    ...(isMatrixError(e) && e),
+                },
             });
         }
     }
@@ -823,7 +838,10 @@ export class ClientWidgetApi extends EventEmitter {
         } catch (e) {
             console.error("error while uploading a file", e);
             await this.transport.reply<IWidgetApiErrorResponseData>(request, {
-                error: { message: "Unexpected error while uploading a file" },
+                error: {
+                    message: "Unexpected error while uploading a file",
+                    ...(isMatrixError(e) && e),
+                },
             });
         }
     }

--- a/src/ClientWidgetApi.ts
+++ b/src/ClientWidgetApi.ts
@@ -833,11 +833,11 @@ export class ClientWidgetApi extends EventEmitter {
     }
 
     private handleDriverError(e: unknown, request: IWidgetApiRequest, message: string) {
-        const errorDetails = this.driver.processError(e);
+        const data = this.driver.processError(e);
         this.transport.reply<IWidgetApiErrorResponseData>(request, {
             error: {
                 message,
-                ...errorDetails,
+                ...data,
             },
         });
     }

--- a/src/WidgetApi.ts
+++ b/src/WidgetApi.ts
@@ -33,7 +33,7 @@ import {
 import { ITransport } from "./transport/ITransport";
 import { PostmessageTransport } from "./transport/PostmessageTransport";
 import { WidgetApiFromWidgetAction, WidgetApiToWidgetAction } from "./interfaces/WidgetApiAction";
-import { IWidgetApiErrorResponseData } from "./interfaces/IWidgetApiErrorResponse";
+import { IWidgetApiErrorResponseData, IWidgetApiErrorResponseDataDetails } from "./interfaces/IWidgetApiErrorResponse";
 import { IStickerActionRequestData } from "./interfaces/StickerAction";
 import { IStickyActionRequestData, IStickyActionResponseData } from "./interfaces/StickyAction";
 import {
@@ -94,6 +94,15 @@ import {
     IUpdateDelayedEventFromWidgetResponseData,
     UpdateDelayedEventAction,
 } from "./interfaces/UpdateDelayedEventAction";
+
+export class WidgetApiResponseError extends Error {
+    public constructor(
+        message: string,
+        public readonly data: IWidgetApiErrorResponseDataDetails,
+    ) {
+        super(message);
+    }
+}
 
 /**
  * API handler for widgets. This raises events for each action

--- a/src/WidgetApi.ts
+++ b/src/WidgetApi.ts
@@ -96,6 +96,10 @@ import {
 } from "./interfaces/UpdateDelayedEventAction";
 
 export class WidgetApiResponseError extends Error {
+    static {
+        this.prototype.name = this.name;
+    }
+
     public constructor(
         message: string,
         public readonly data: IWidgetApiErrorResponseDataDetails,

--- a/src/driver/WidgetDriver.ts
+++ b/src/driver/WidgetDriver.ts
@@ -19,6 +19,7 @@ import {
     IOpenIDCredentials,
     OpenIDRequestState,
     SimpleObservable,
+    IMatrixApiError,
     IRoomEvent,
     IRoomAccountData,
     ITurnServer,
@@ -357,5 +358,16 @@ export abstract class WidgetDriver {
         contentUri: string,
     ): Promise<{ file: XMLHttpRequestBodyInit }> {
         throw new Error("Download file is not implemented");
+    }
+
+    /**
+     * Expresses an error thrown by a Matrix API request made by this driver
+     * in a format compatible with the Widget API.
+     * @param error The error to handle.
+     * @returns The error expressed as a {@link IMatrixApiError},
+     * or undefined if it cannot be expressed as one.
+     */
+    public processError(error: unknown): IMatrixApiError | undefined {
+        return undefined;
     }
 }

--- a/src/driver/WidgetDriver.ts
+++ b/src/driver/WidgetDriver.ts
@@ -19,10 +19,10 @@ import {
     IOpenIDCredentials,
     OpenIDRequestState,
     SimpleObservable,
-    IMatrixApiError,
     IRoomEvent,
     IRoomAccountData,
     ITurnServer,
+    IWidgetApiErrorResponseDataDetails,
     UpdateDelayedEventAction,
 } from "..";
 
@@ -361,13 +361,12 @@ export abstract class WidgetDriver {
     }
 
     /**
-     * Expresses an error thrown by a Matrix API request made by this driver
-     * in a format compatible with the Widget API.
+     * Expresses an error thrown by this driver in a format compatible with the Widget API.
      * @param error The error to handle.
-     * @returns The error expressed as a {@link IMatrixApiError},
+     * @returns The error expressed as a {@link IWidgetApiErrorResponseDataDetails},
      * or undefined if it cannot be expressed as one.
      */
-    public processError(error: unknown): IMatrixApiError | undefined {
+    public processError(error: unknown): IWidgetApiErrorResponseDataDetails | undefined {
         return undefined;
     }
 }

--- a/src/interfaces/IWidgetApiErrorResponse.ts
+++ b/src/interfaces/IWidgetApiErrorResponse.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Matrix.org Foundation C.I.C.
+ * Copyright 2020 - 2024 The Matrix.org Foundation C.I.C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,34 +16,42 @@
 
 import { IWidgetApiResponse, IWidgetApiResponseData } from "./IWidgetApiResponse";
 
-interface IWidgetApiErrorData {
-    message: string;
+/**
+ * The format of errors returned by Matrix API requests
+ * made by a WidgetDriver.
+ */
+export interface IMatrixApiError {
+    /** The HTTP status code of the associated request. */
+    http_status: number;  // eslint-disable-line camelcase
+    /** Any HTTP response headers that are relevant to the error. */
+    http_headers: {[name: string]: string};  // eslint-disable-line camelcase
+    /** The URL of the failed request. */
+    url: string;
+    /** @see {@link https://spec.matrix.org/latest/client-server-api/#standard-error-response} */
+    response: {
+        errcode: string;
+        error: string;
+    } & IWidgetApiResponseData; // extensible
 }
 
-interface IMatrixErrorData {
-    httpStatus?: number;
-    errcode?: string;
+export interface IWidgetApiErrorResponseDataDetails extends IWidgetApiResponseData {
+    /** Set if the error came from a Matrix API request made by a widget driver */
+    matrix_api_error?: IMatrixApiError;  // eslint-disable-line camelcase
 }
 
 export interface IWidgetApiErrorResponseData extends IWidgetApiResponseData {
-    error: IWidgetApiErrorData & IMatrixErrorData;
-}
-
-export function isMatrixError(err: unknown): err is IMatrixErrorData {
-    return typeof err === "object" && err !== null && (
-        "httpStatus" in err && typeof err.httpStatus === "number" ||
-        "errcode" in err && typeof err.errcode === "string"
-    );
+    error: {
+        /** A user-friendly string describing the error */
+        message: string;
+    } & IWidgetApiErrorResponseDataDetails;
 }
 
 export interface IWidgetApiErrorResponse extends IWidgetApiResponse {
     response: IWidgetApiErrorResponseData;
 }
 
-export function isErrorResponse(responseData: IWidgetApiResponseData): boolean {
-    if ("error" in responseData) {
-        const err = <IWidgetApiErrorResponseData>responseData;
-        return !!err.error.message;
-    }
-    return false;
+export function isErrorResponse(responseData: IWidgetApiResponseData): responseData is IWidgetApiErrorResponseData {
+    const error = responseData.error;
+    return typeof error === "object" && error !== null &&
+        "message" in error && typeof error.message === "string";
 }

--- a/src/interfaces/IWidgetApiErrorResponse.ts
+++ b/src/interfaces/IWidgetApiErrorResponse.ts
@@ -34,7 +34,7 @@ export interface IMatrixApiError {
     } & IWidgetApiResponseData; // extensible
 }
 
-export interface IWidgetApiErrorResponseDataDetails extends IWidgetApiResponseData {
+export interface IWidgetApiErrorResponseDataDetails {
     /** Set if the error came from a Matrix API request made by a widget driver */
     matrix_api_error?: IMatrixApiError;  // eslint-disable-line camelcase
 }

--- a/src/interfaces/IWidgetApiErrorResponse.ts
+++ b/src/interfaces/IWidgetApiErrorResponse.ts
@@ -16,10 +16,24 @@
 
 import { IWidgetApiResponse, IWidgetApiResponseData } from "./IWidgetApiResponse";
 
+interface IWidgetApiErrorData {
+    message: string;
+}
+
+interface IMatrixErrorData {
+    httpStatus?: number;
+    errcode?: string;
+}
+
 export interface IWidgetApiErrorResponseData extends IWidgetApiResponseData {
-    error: {
-        message: string;
-    };
+    error: IWidgetApiErrorData & IMatrixErrorData;
+}
+
+export function isMatrixError(err: unknown): err is IMatrixErrorData {
+    return typeof err === "object" && err !== null && (
+        "httpStatus" in err && typeof err.httpStatus === "number" ||
+        "errcode" in err && typeof err.errcode === "string"
+    );
 }
 
 export interface IWidgetApiErrorResponse extends IWidgetApiResponse {

--- a/src/transport/ITransport.ts
+++ b/src/transport/ITransport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Matrix.org Foundation C.I.C.
+ * Copyright 2020 - 2024 The Matrix.org Foundation C.I.C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,11 +71,12 @@ export interface ITransport extends EventEmitter {
 
     /**
      * Sends a request to the remote end.
-     * @param {WidgetApiAction} action The action to send.
-     * @param {IWidgetApiRequestData} data The request data.
-     * @returns {Promise<IWidgetApiResponseData>} A promise which resolves
-     * to the remote end's response, or throws with an Error if the request
-     * failed.
+     * @param action The action to send.
+     * @param data The request data.
+     * @returns A promise which resolves to the remote end's response.
+     * @throws {Error} if the request failed with a generic error.
+     * @throws {WidgetApiResponseError} if the request failed with error details
+     * that can be communicated to the Widget API.
      */
     send<T extends IWidgetApiRequestData, R extends IWidgetApiResponseData = IWidgetApiAcknowledgeResponseData>(
         action: WidgetApiAction,
@@ -88,9 +89,10 @@ export interface ITransport extends EventEmitter {
      * data.
      * @param {WidgetApiAction} action The action to send.
      * @param {IWidgetApiRequestData} data The request data.
-     * @returns {Promise<IWidgetApiResponseData>} A promise which resolves
-     * to the remote end's response, or throws with an Error if the request
-     * failed.
+     * @returns {Promise<IWidgetApiResponseData>} A promise which resolves to the remote end's response
+     * @throws {Error} if the request failed with a generic error.
+     * @throws {WidgetApiResponseError} if the request failed with error details
+     * that can be communicated to the Widget API.
      */
     sendComplete<T extends IWidgetApiRequestData, R extends IWidgetApiResponse>(action: WidgetApiAction, data: T)
         : Promise<R>;

--- a/test/ClientWidgetApi-test.ts
+++ b/test/ClientWidgetApi-test.ts
@@ -246,6 +246,8 @@ describe('ClientWidgetApi', () => {
         });
 
         it('should reject requests when the driver throws an exception', async () => {
+            const roomId = '!room:example.org';
+
             driver.sendEvent.mockRejectedValue(
                 new Error("M_BAD_JSON: Content must be a JSON object"),
             );
@@ -258,6 +260,7 @@ describe('ClientWidgetApi', () => {
                 data: {
                     type: 'm.room.message',
                     content: 'hello',
+                    room_id: roomId,
                 },
             };
 
@@ -276,6 +279,8 @@ describe('ClientWidgetApi', () => {
         });
 
         it('should reject with Matrix API error response thrown by driver', async () => {
+            const roomId = '!room:example.org';
+
             driver.processError.mockImplementation(processCustomMatrixError);
 
             driver.sendEvent.mockRejectedValue(
@@ -297,6 +302,7 @@ describe('ClientWidgetApi', () => {
                 data: {
                     type: 'm.room.message',
                     content: 'hello',
+                    room_id: roomId,
                 },
             };
 
@@ -329,6 +335,8 @@ describe('ClientWidgetApi', () => {
 
     describe('send_event action for delayed events', () => {
         it('fails to send delayed events', async () => {
+            const roomId = '!room:example.org';
+
             const event: ISendEventFromWidgetActionRequest = {
                 api: WidgetApiDirection.FromWidget,
                 widgetId: 'test',
@@ -338,6 +346,7 @@ describe('ClientWidgetApi', () => {
                     type: 'm.room.message',
                     content: {},
                     delay: 5000,
+                    room_id: roomId,
                 },
             };
 
@@ -458,6 +467,8 @@ describe('ClientWidgetApi', () => {
         });
 
         it('should reject requests when the driver throws an exception', async () => {
+            const roomId = '!room:example.org';
+
             driver.sendDelayedEvent.mockRejectedValue(
                 new Error("M_BAD_JSON: Content must be a JSON object"),
             );
@@ -470,6 +481,7 @@ describe('ClientWidgetApi', () => {
                 data: {
                     type: 'm.room.message',
                     content: 'hello',
+                    room_id: roomId,
                     delay: 5000,
                     parent_delay_id: 'fp',
                 },
@@ -491,6 +503,8 @@ describe('ClientWidgetApi', () => {
         });
 
         it('should reject with Matrix API error response thrown by driver', async () => {
+            const roomId = '!room:example.org';
+
             driver.processError.mockImplementation(processCustomMatrixError);
 
             driver.sendDelayedEvent.mockRejectedValue(
@@ -512,6 +526,7 @@ describe('ClientWidgetApi', () => {
                 data: {
                     type: 'm.room.message',
                     content: 'hello',
+                    room_id: roomId,
                     delay: 5000,
                     parent_delay_id: 'fp',
                 },

--- a/test/ClientWidgetApi-test.ts
+++ b/test/ClientWidgetApi-test.ts
@@ -36,6 +36,7 @@ import {
     ISendEventFromWidgetActionRequest,
     IUpdateDelayedEventFromWidgetActionRequest,
     IUploadFileActionFromWidgetActionRequest,
+    IWidgetApiErrorResponseDataDetails,
     UpdateDelayedEventAction,
 } from '../src';
 import { IGetMediaConfigActionFromWidgetActionRequest } from '../src/interfaces/GetMediaConfigAction';
@@ -70,15 +71,17 @@ class CustomMatrixError extends Error {
     }
 }
 
-function processCustomMatrixError(e: unknown): IMatrixApiError | undefined {
+function processCustomMatrixError(e: unknown): IWidgetApiErrorResponseDataDetails | undefined {
     return e instanceof CustomMatrixError ? {
-        http_status: e.httpStatus,
-        http_headers: {},
-        url: '',
-        response: {
-            errcode: e.name,
-            error: e.message,
-            ...e.data,
+        matrix_api_error: {
+            http_status: e.httpStatus,
+            http_headers: {},
+            url: '',
+            response: {
+                errcode: e.name,
+                error: e.message,
+                ...e.data,
+            },
         },
     } : undefined;
 }

--- a/test/ClientWidgetApi-test.ts
+++ b/test/ClientWidgetApi-test.ts
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 Nordeck IT + Consulting GmbH.
+ * Copyright 2024 The Matrix.org Foundation C.I.C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +31,7 @@ import { Widget } from '../src/models/Widget';
 import { PostmessageTransport } from '../src/transport/PostmessageTransport';
 import {
     IDownloadFileActionFromWidgetActionRequest,
+    IMatrixApiError,
     IReadEventFromWidgetActionRequest,
     ISendEventFromWidgetActionRequest,
     IUpdateDelayedEventFromWidgetActionRequest,
@@ -55,6 +57,30 @@ function createRoomEvent(event: Partial<IRoomEvent> = {}): IRoomEvent {
         unsigned: {},
         ...event,
     };
+}
+
+class CustomMatrixError extends Error {
+    constructor(
+        message: string,
+        public readonly httpStatus: number,
+        public readonly name: string,
+        public readonly data: Record<string, unknown>,
+    ) {
+        super(message);
+    }
+}
+
+function processCustomMatrixError(e: unknown): IMatrixApiError | undefined {
+    return e instanceof CustomMatrixError ? {
+        http_status: e.httpStatus,
+        http_headers: {},
+        url: '',
+        response: {
+            errcode: e.name,
+            error: e.message,
+            ...e.data,
+        },
+    } : undefined;
 }
 
 describe('ClientWidgetApi', () => {
@@ -93,6 +119,7 @@ describe('ClientWidgetApi', () => {
             getMediaConfig: jest.fn(),
             uploadFile: jest.fn(),
             downloadFile: jest.fn(),
+            processError: jest.fn(),
         } as Partial<WidgetDriver> as jest.Mocked<WidgetDriver>;
 
         clientWidgetApi = new ClientWidgetApi(
@@ -213,6 +240,87 @@ describe('ClientWidgetApi', () => {
                 '',
                 roomId,
             );
+        });
+
+        it('should reject requests when the driver throws an exception', async () => {
+            driver.sendEvent.mockRejectedValue(
+                new Error("M_BAD_JSON: Content must be a JSON object"),
+            );
+
+            const event: ISendEventFromWidgetActionRequest = {
+                api: WidgetApiDirection.FromWidget,
+                widgetId: 'test',
+                requestId: '0',
+                action: WidgetApiFromWidgetAction.SendEvent,
+                data: {
+                    type: 'm.room.message',
+                    content: 'hello',
+                },
+            };
+
+            await loadIframe([
+                `org.matrix.msc2762.timeline:${event.data.room_id}`,
+                `org.matrix.msc2762.send.event:${event.data.type}`,
+            ]);
+
+            emitEvent(new CustomEvent('', { detail: event }));
+
+            await waitFor(() => {
+                expect(transport.reply).toBeCalledWith(event, {
+                    error: { message: 'Error sending event' },
+                });
+            });
+        });
+
+        it('should reject with Matrix API error response thrown by driver', async () => {
+            driver.processError.mockImplementation(processCustomMatrixError);
+
+            driver.sendEvent.mockRejectedValue(
+                new CustomMatrixError(
+                    'failed to send event',
+                    400,
+                    'M_NOT_JSON',
+                    {
+                        reason: 'Content must be a JSON object.',
+                    },
+                ),
+            );
+
+            const event: ISendEventFromWidgetActionRequest = {
+                api: WidgetApiDirection.FromWidget,
+                widgetId: 'test',
+                requestId: '0',
+                action: WidgetApiFromWidgetAction.SendEvent,
+                data: {
+                    type: 'm.room.message',
+                    content: 'hello',
+                },
+            };
+
+            await loadIframe([
+                `org.matrix.msc2762.timeline:${event.data.room_id}`,
+                `org.matrix.msc2762.send.event:${event.data.type}`,
+            ]);
+
+            emitEvent(new CustomEvent('', { detail: event }));
+
+            await waitFor(() => {
+                expect(transport.reply).toBeCalledWith(event, {
+                    error: {
+                        message: 'Error sending event',
+                        matrix_api_error: {
+                            http_status: 400,
+                            http_headers: {},
+                            url: '',
+                            response: {
+                                errcode: 'M_NOT_JSON',
+                                error: 'failed to send event',
+                                reason: 'Content must be a JSON object.',
+                            },
+                        } satisfies IMatrixApiError,
+                    },
+                });
+            });
         });
     });
 
@@ -761,6 +869,51 @@ describe('ClientWidgetApi', () => {
                 });
             });
         });
+
+        it('should reject with Matrix API error response thrown by driver', async () => {
+            driver.processError.mockImplementation(processCustomMatrixError);
+
+            driver.readEventRelations.mockRejectedValue(
+                new CustomMatrixError(
+                    'failed to read relations',
+                    403,
+                    'M_FORBIDDEN',
+                    {
+                        reason: "You don't have permission to access that event",
+                    },
+                ),
+            );
+
+            const event: IReadRelationsFromWidgetActionRequest = {
+                api: WidgetApiDirection.FromWidget,
+                widgetId: 'test',
+                requestId: '0',
+                action: WidgetApiFromWidgetAction.MSC3869ReadRelations,
+                data: { event_id: '$event' },
+            };
+
+            await loadIframe();
+
+            emitEvent(new CustomEvent('', { detail: event }));
+
+            await waitFor(() => {
+                expect(transport.reply).toBeCalledWith(event, {
+                    error: {
+                        message: 'Unexpected error while reading relations',
+                        matrix_api_error: {
+                            http_status: 403,
+                            http_headers: {},
+                            url: '',
+                            response: {
+                                errcode: 'M_FORBIDDEN',
+                                error: 'failed to read relations',
+                                reason: "You don't have permission to access that event",
+                            },
+                        } satisfies IMatrixApiError,
+                    },
+                });
+            });
+        });
     });
 
     describe('org.matrix.msc3973.user_directory_search action', () => {
@@ -991,6 +1144,55 @@ describe('ClientWidgetApi', () => {
                 });
             });
         });
+
+        it('should reject with Matrix API error response thrown by driver', async () => {
+            driver.processError.mockImplementation(processCustomMatrixError);
+
+            driver.searchUserDirectory.mockRejectedValue(
+                new CustomMatrixError(
+                    'failed to search the user directory',
+                    429,
+                    'M_LIMIT_EXCEEDED',
+                    {
+                        reason: 'Too many requests',
+                        retry_after_ms: 2000,
+                    },
+                ),
+            );
+
+            const event: IUserDirectorySearchFromWidgetActionRequest = {
+                api: WidgetApiDirection.FromWidget,
+                widgetId: 'test',
+                requestId: '0',
+                action: WidgetApiFromWidgetAction.MSC3973UserDirectorySearch,
+                data: { search_term: 'foo' },
+            };
+
+            await loadIframe([
+                'org.matrix.msc3973.user_directory_search',
+            ]);
+
+            emitEvent(new CustomEvent('', { detail: event }));
+
+            await waitFor(() => {
+                expect(transport.reply).toBeCalledWith(event, {
+                    error: {
+                        message: 'Unexpected error while searching in the user directory',
+                        matrix_api_error: {
+                            http_status: 429,
+                            http_headers: {},
+                            url: '',
+                            response: {
+                                errcode: 'M_LIMIT_EXCEEDED',
+                                error: 'failed to search the user directory',
+                                reason: 'Too many requests',
+                                retry_after_ms: 2000,
+                            },
+                        } satisfies IMatrixApiError,
+                    },
+                });
+            });
+        });
     });
 
     describe('org.matrix.msc4039.get_media_config action', () => {
@@ -1083,6 +1285,55 @@ describe('ClientWidgetApi', () => {
                 });
             });
         });
+
+        it('should reject with Matrix API error response thrown by driver', async () => {
+            driver.processError.mockImplementation(processCustomMatrixError);
+
+            driver.getMediaConfig.mockRejectedValue(
+                new CustomMatrixError(
+                    'failed to get the media configuration',
+                    429,
+                    'M_LIMIT_EXCEEDED',
+                    {
+                        reason: 'Too many requests',
+                        retry_after_ms: 2000,
+                    },
+                ),
+            );
+
+            const event: IGetMediaConfigActionFromWidgetActionRequest = {
+                api: WidgetApiDirection.FromWidget,
+                widgetId: 'test',
+                requestId: '0',
+                action: WidgetApiFromWidgetAction.MSC4039GetMediaConfigAction,
+                data: {},
+            };
+
+            await loadIframe([
+                'org.matrix.msc4039.upload_file',
+            ]);
+
+            emitEvent(new CustomEvent('', { detail: event }));
+
+            await waitFor(() => {
+                expect(transport.reply).toBeCalledWith(event, {
+                    error: {
+                        message: 'Unexpected error while getting the media configuration',
+                        matrix_api_error: {
+                            http_status: 429,
+                            http_headers: {},
+                            url: '',
+                            response: {
+                                errcode: 'M_LIMIT_EXCEEDED',
+                                error: 'failed to get the media configuration',
+                                reason: 'Too many requests',
+                                retry_after_ms: 2000,
+                            },
+                        } satisfies IMatrixApiError,
+                    },
+                });
+            });
+        });
     });
 
     describe('MSC4039', () => {
@@ -1157,7 +1408,7 @@ describe('ClientWidgetApi', () => {
         });
 
         it('should reject requests when the driver throws an exception', async () => {
-            driver.getMediaConfig.mockRejectedValue(
+            driver.uploadFile.mockRejectedValue(
                 new Error("M_LIMIT_EXCEEDED: Too many requests"),
             );
 
@@ -1180,6 +1431,57 @@ describe('ClientWidgetApi', () => {
             await waitFor(() => {
                 expect(transport.reply).toBeCalledWith(event, {
                     error: { message: 'Unexpected error while uploading a file' },
+                });
+            });
+        });
+
+        it('should reject with Matrix API error response thrown by driver', async () => {
+            driver.processError.mockImplementation(processCustomMatrixError);
+
+            driver.uploadFile.mockRejectedValue(
+                new CustomMatrixError(
+                    'failed to upload a file',
+                    429,
+                    'M_LIMIT_EXCEEDED',
+                    {
+                        reason: 'Too many requests',
+                        retry_after_ms: 2000,
+                    },
+                ),
+            );
+
+            const event: IUploadFileActionFromWidgetActionRequest = {
+                api: WidgetApiDirection.FromWidget,
+                widgetId: 'test',
+                requestId: '0',
+                action: WidgetApiFromWidgetAction.MSC4039UploadFileAction,
+                data: {
+                    file: 'data',
+                },
+            };
+
+            await loadIframe([
+                'org.matrix.msc4039.upload_file',
+            ]);
+
+            emitEvent(new CustomEvent('', { detail: event }));
+
+            await waitFor(() => {
+                expect(transport.reply).toBeCalledWith(event, {
+                    error: {
+                        message: 'Unexpected error while uploading a file',
+                        matrix_api_error: {
+                            http_status: 429,
+                            http_headers: {},
+                            url: '',
+                            response: {
+                                errcode: 'M_LIMIT_EXCEEDED',
+                                error: 'failed to upload a file',
+                                reason: 'Too many requests',
+                                retry_after_ms: 2000,
+                            },
+                        } satisfies IMatrixApiError,
+                    },
                 });
             });
         });
@@ -1237,7 +1539,7 @@ describe('ClientWidgetApi', () => {
         });
 
         it('should reject requests when the driver throws an exception', async () => {
-            driver.getMediaConfig.mockRejectedValue(
+            driver.downloadFile.mockRejectedValue(
                 new Error("M_LIMIT_EXCEEDED: Too many requests"),
             );
 
@@ -1260,6 +1562,57 @@ describe('ClientWidgetApi', () => {
             await waitFor(() => {
                 expect(transport.reply).toBeCalledWith(event, {
                     error: { message: 'Unexpected error while downloading a file' },
+                });
+            });
+        });
+
+        it('should reject with Matrix API error response thrown by driver', async () => {
+            driver.processError.mockImplementation(processCustomMatrixError);
+
+            driver.downloadFile.mockRejectedValue(
+                new CustomMatrixError(
+                    'failed to download a file',
+                    429,
+                    'M_LIMIT_EXCEEDED',
+                    {
+                        reason: 'Too many requests',
+                        retry_after_ms: 2000,
+                    },
+                ),
+            );
+
+            const event: IDownloadFileActionFromWidgetActionRequest = {
+                api: WidgetApiDirection.FromWidget,
+                widgetId: 'test',
+                requestId: '0',
+                action: WidgetApiFromWidgetAction.MSC4039DownloadFileAction,
+                data: {
+                    content_uri: 'mxc://example.com/test_file',
+                },
+            };
+
+            await loadIframe([
+                'org.matrix.msc4039.download_file',
+            ]);
+
+            emitEvent(new CustomEvent('', { detail: event }));
+
+            await waitFor(() => {
+                expect(transport.reply).toBeCalledWith(event, {
+                    error: {
+                        message: 'Unexpected error while downloading a file',
+                        matrix_api_error: {
+                            http_status: 429,
+                            http_headers: {},
+                            url: '',
+                            response: {
+                                errcode: 'M_LIMIT_EXCEEDED',
+                                error: 'failed to download a file',
+                                reason: 'Too many requests',
+                                retry_after_ms: 2000,
+                            },
+                        } satisfies IMatrixApiError,
+                    },
                 });
             });
         });

--- a/test/WidgetApi-test.ts
+++ b/test/WidgetApi-test.ts
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 Nordeck IT + Consulting GmbH.
+ * Copyright 2024 The Matrix.org Foundation C.I.C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Currently, error responses from CS-API requests are re-thrown/rejected without their HTTP status code or `errcode` string.  This PR passes them along, because otherwise clients that may run either standalone or as a widget cannot reliably use HTTP status codes on error responses, as the latter would not receive them.

Signed-off-by: Andrew Ferrazzutti <andrewf@element.io>