### PR TITLE
Add UPDATE_STATE widget api version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ lib/
 dist/
 .npmrc
 .idea
+.vscode
 
 # Logs
 logs

--- a/src/interfaces/ApiVersion.ts
+++ b/src/interfaces/ApiVersion.ts
@@ -22,6 +22,7 @@ export enum MatrixApiVersion {
 
 export enum UnstableApiVersion {
     MSC2762 = "org.matrix.msc2762",
+    MSC2762_UPDATE_STATE = "org.matrix.msc2762_update_state",
     MSC2871 = "org.matrix.msc2871",
     MSC2873 = "org.matrix.msc2873",
     MSC2931 = "org.matrix.msc2931",
@@ -41,6 +42,7 @@ export const CurrentApiVersions: ApiVersion[] = [
     MatrixApiVersion.Prerelease2,
     //MatrixApiVersion.V010,
     UnstableApiVersion.MSC2762,
+    UnstableApiVersion.MSC2762_UPDATE_STATE,
     UnstableApiVersion.MSC2871,
     UnstableApiVersion.MSC2873,
     UnstableApiVersion.MSC2931,

--- a/test/ClientWidgetApi-test.ts
+++ b/test/ClientWidgetApi-test.ts
@@ -19,17 +19,17 @@ import { waitFor } from '@testing-library/dom';
 
 import { ClientWidgetApi } from "../src/ClientWidgetApi";
 import { WidgetDriver } from "../src/driver/WidgetDriver";
-import { UnstableApiVersion } from '../src/interfaces/ApiVersion';
-import { Capability } from '../src/interfaces/Capabilities';
-import { IRoomEvent } from '../src/interfaces/IRoomEvent';
-import { IWidgetApiRequest } from '../src/interfaces/IWidgetApiRequest';
-import { IReadRelationsFromWidgetActionRequest } from '../src/interfaces/ReadRelationsAction';
-import { ISupportedVersionsActionRequest } from '../src/interfaces/SupportedVersionsAction';
-import { IUserDirectorySearchFromWidgetActionRequest } from '../src/interfaces/UserDirectorySearchAction';
-import { WidgetApiFromWidgetAction, WidgetApiToWidgetAction } from '../src/interfaces/WidgetApiAction';
-import { WidgetApiDirection } from '../src/interfaces/WidgetApiDirection';
-import { Widget } from '../src/models/Widget';
-import { PostmessageTransport } from '../src/transport/PostmessageTransport';
+import { CurrentApiVersions, UnstableApiVersion } from "../src/interfaces/ApiVersion";
+import { Capability } from "../src/interfaces/Capabilities";
+import { IRoomEvent } from "../src/interfaces/IRoomEvent";
+import { IWidgetApiRequest } from "../src/interfaces/IWidgetApiRequest";
+import { IReadRelationsFromWidgetActionRequest } from "../src/interfaces/ReadRelationsAction";
+import { ISupportedVersionsActionRequest } from "../src/interfaces/SupportedVersionsAction";
+import { IUserDirectorySearchFromWidgetActionRequest } from "../src/interfaces/UserDirectorySearchAction";
+import { WidgetApiFromWidgetAction, WidgetApiToWidgetAction } from "../src/interfaces/WidgetApiAction";
+import { WidgetApiDirection } from "../src/interfaces/WidgetApiDirection";
+import { Widget } from "../src/models/Widget";
+import { PostmessageTransport } from "../src/transport/PostmessageTransport";
 import {
     IDownloadFileActionFromWidgetActionRequest,
     IGetOpenIDActionRequest,
@@ -792,6 +792,14 @@ describe('ClientWidgetApi', () => {
             const roomId = '!room:example.org';
             const otherRoomId = '!other-room:example.org';
             clientWidgetApi.setViewedRoomId(roomId);
+
+            jest.spyOn(transport, "send").mockImplementation((action, data) => {
+                if (action === WidgetApiToWidgetAction.SupportedApiVersions) {
+                    return Promise.resolve({ supported_versions: CurrentApiVersions });
+                }
+                return Promise.resolve({});
+            });
+
             const topicEvent = createRoomEvent({
                 room_id: roomId,
                 type: 'm.room.topic',


### PR DESCRIPTION
Required for: https://github.com/matrix-org/matrix-js-sdk/pull/4652 (this pr also provides more background on why this is needed)

Let the client only send UpdateState if the widget supports it.
