### PR TITLE
Run the 'Prevent blocked' check whenever a PR branch is updated

### DIFF
--- a/.github/workflows/blocked.yaml
+++ b/.github/workflows/blocked.yaml
@@ -1,7 +1,7 @@
 name: Prevent blocked
 on:
     pull_request_target:
-        types: [opened, labeled, unlabeled]
+        types: [opened, labeled, unlabeled, synchronize]
 jobs:
     prevent-blocked:
         name: Prevent blocked


### PR DESCRIPTION
Because we're now [requiring](https://github.com/element-hq/it-internal/issues/1896) the 'Prevent blocked' check to pass before merging a PR, GitHub Actions apparently expects it to be associated with the latest Git ref of the PR's branch whenever the branch is updated. Therefore we need to re-run the workflow on the 'synchronize' event.