### PR TITLE
Publish releases to npm as a trusted publisher

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,8 @@ on:
                     - major
 concurrency: release
 permissions:
-    contents: write
+    id-token: write # Allow npm to authenticate as a trusted publisher
+    contents: write # Allow creating a release
 jobs:
     release:
         name: "Release & Publish"
@@ -44,16 +45,15 @@ jobs:
               run: yarn build
 
             - name: 🚀 Publish to npm
-              id: npm-publish
-              uses: JS-DevTools/npm-publish@v3
-              with:
-                  token: ${{ secrets.NPM_TOKEN }}
-                  access: public
+              # We use npm since Yarn Classic doesn't support trusted publishing
+              run: |
+                  npm publish --provenance --ignore-scripts
+                  echo "VERSION=$(jq '.version' --raw-output package.json)" >> "$GITHUB_ENV"
 
             - name: 🧬 Create release
               uses: softprops/action-gh-release@v2
               with:
-                  tag_name: v${{ steps.npm-publish.outputs.version }}
-                  body: ${{ steps.npm-publish.outputs.version }} Release
+                  tag_name: v${{ env.VERSION }}
+                  body: ${{ env.VERSION }} Release
                   draft: false
                   prerelease: false


### PR DESCRIPTION
npm has recently limited the lifetime of all access tokens to 90 days (https://gh.io/npm-token-changes), so it would be a bit inconvenient to stick to our current access token-based method of publishing releases. Meanwhile npm has implemented a more secure publishing method based on OIDC in which you tell the registry that a particular GitHub Actions workflow should be a "trusted publisher" for a given package, and then the CLI will authenticate automatically. (https://docs.npmjs.com/trusted-publishers)

I've already set it up on the registry side. Let's see if this works next time we release.