### PR TITLE
Revert "minor version bump"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "matrix-widget-api",
-    "version": "1.14.0",
+    "version": "1.13.1",
     "description": "Matrix Widget API SDK",
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",


### PR DESCRIPTION
This reverts commit ad90fd458d7ab8ec3eefc04ecb1a2b6298bd1051.
Revert because the last run of the release workflow failed, and the next run should use the same version instead of bumping it again.