### PR TITLE
Add LiveKit RTC endpoint support (MSC4533)

### DIFF
--- a/src/ClientWidgetApi.ts
+++ b/src/ClientWidgetApi.ts
@@ -111,6 +111,12 @@ import {
     IDownloadFileActionFromWidgetActionRequest,
     IDownloadFileActionFromWidgetResponseData,
 } from "./interfaces/DownloadFileAction";
+import {
+    IRtcLivekitDelegateDelayedLeaveFromWidgetActionRequest,
+    IRtcLivekitDelegateDelayedLeaveFromWidgetResponseData,
+    IRtcLivekitGetTokenFromWidgetActionRequest,
+    IRtcLivekitGetTokenFromWidgetResponseData,
+} from "./interfaces/RtcLivekitActions";
 import { IThemeChangeActionRequestData } from "./interfaces/ThemeChangeAction";
 import { IUpdateStateToWidgetRequestData } from "./interfaces/UpdateStateAction";
 import { IToDeviceMessage } from "./interfaces/IToDeviceMessage";
@@ -1030,6 +1036,42 @@ export class ClientWidgetApi extends EventEmitter {
         }
     }
 
+    private async handleRtcLivekitGetToken(request: IRtcLivekitGetTokenFromWidgetActionRequest): Promise<void> {
+        if (!this.hasCapability(MatrixCapabilities.MSC4533RtcLivekitGetToken)) {
+            return this.transport.reply<IWidgetApiErrorResponseData>(request, {
+                error: { message: "Missing capability" },
+            });
+        }
+
+        try {
+            const result = await this.driver.getRtcLivekitToken(request.data);
+
+            return this.transport.reply<IRtcLivekitGetTokenFromWidgetResponseData>(request, result);
+        } catch (e) {
+            console.error("error while getting a LiveKit token", e);
+            this.handleDriverError(e, request, "Unexpected error while getting a LiveKit token");
+        }
+    }
+
+    private async handleRtcLivekitDelegateDelayedLeave(
+        request: IRtcLivekitDelegateDelayedLeaveFromWidgetActionRequest,
+    ): Promise<void> {
+        if (!this.hasCapability(MatrixCapabilities.MSC4533RtcLivekitDelegateDelayedLeave)) {
+            return this.transport.reply<IWidgetApiErrorResponseData>(request, {
+                error: { message: "Missing capability" },
+            });
+        }
+
+        try {
+            const result = await this.driver.delegateRtcLivekitDelayedLeave(request.data);
+
+            return this.transport.reply<IRtcLivekitDelegateDelayedLeaveFromWidgetResponseData>(request, result);
+        } catch (e) {
+            console.error("error while delegating a LiveKit delayed leave", e);
+            this.handleDriverError(e, request, "Unexpected error while delegating a LiveKit delayed leave");
+        }
+    }
+
     private handleDriverError(e: unknown, request: IWidgetApiRequest, message: string): void {
         const data = this.driver.processError(e);
         this.transport.reply<IWidgetApiErrorResponseData>(request, {
@@ -1085,6 +1127,12 @@ export class ClientWidgetApi extends EventEmitter {
                     return this.handleDownloadFile(<IDownloadFileActionFromWidgetActionRequest>ev.detail);
                 case WidgetApiFromWidgetAction.MSC4157UpdateDelayedEvent:
                     return this.handleUpdateDelayedEvent(<IUpdateDelayedEventFromWidgetActionRequest>ev.detail);
+                case WidgetApiFromWidgetAction.MSC4533RtcLivekitGetToken:
+                    return this.handleRtcLivekitGetToken(<IRtcLivekitGetTokenFromWidgetActionRequest>ev.detail);
+                case WidgetApiFromWidgetAction.MSC4533RtcLivekitDelegateDelayedLeave:
+                    return this.handleRtcLivekitDelegateDelayedLeave(
+                        <IRtcLivekitDelegateDelayedLeaveFromWidgetActionRequest>ev.detail,
+                    );
 
                 default:
                     return this.transport.reply(ev.detail, <IWidgetApiErrorResponseData>{

--- a/src/WidgetApi.ts
+++ b/src/WidgetApi.ts
@@ -16,7 +16,7 @@
 
 import { EventEmitter } from "events";
 
-import { Capability } from "./interfaces/Capabilities";
+import { Capability, MatrixCapabilities } from "./interfaces/Capabilities";
 import { IWidgetApiRequest, IWidgetApiRequestEmptyData } from "./interfaces/IWidgetApiRequest";
 import { IWidgetApiAcknowledgeResponseData } from "./interfaces/IWidgetApiResponse";
 import { WidgetApiDirection } from "./interfaces/WidgetApiDirection";
@@ -94,6 +94,12 @@ import {
     IDownloadFileActionFromWidgetRequestData,
     IDownloadFileActionFromWidgetResponseData,
 } from "./interfaces/DownloadFileAction";
+import {
+    IRtcLivekitDelegateDelayedLeaveFromWidgetRequestData,
+    IRtcLivekitDelegateDelayedLeaveFromWidgetResponseData,
+    IRtcLivekitGetTokenFromWidgetRequestData,
+    IRtcLivekitGetTokenFromWidgetResponseData,
+} from "./interfaces/RtcLivekitActions";
 import {
     IUpdateDelayedEventFromWidgetRequestData,
     IUpdateDelayedEventFromWidgetResponseData,
@@ -303,6 +309,26 @@ export class WidgetApi extends EventEmitter {
      */
     public requestCapabilityToReceiveRoomAccountData(eventType: string): void {
         this.requestCapability(WidgetEventCapability.forRoomAccountData(EventDirection.Receive, eventType).raw);
+    }
+
+    /**
+     * Requests the capability to obtain a JWT for a LiveKit SFU through the client.
+     * It is not guaranteed to be allowed, but will be asked for if the negotiation
+     * has not already happened.
+     * @see {@link https://github.com/matrix-org/matrix-spec-proposals/pull/4533|MSC4533}
+     */
+    public requestCapabilityToGetRtcLivekitToken(): void {
+        this.requestCapability(MatrixCapabilities.MSC4533RtcLivekitGetToken);
+    }
+
+    /**
+     * Requests the capability to hand a MatrixRTC session's delayed leave event over
+     * to the server through the client. It is not guaranteed to be allowed, but will
+     * be asked for if the negotiation has not already happened.
+     * @see {@link https://github.com/matrix-org/matrix-spec-proposals/pull/4533|MSC4533}
+     */
+    public requestCapabilityToDelegateRtcLivekitDelayedLeave(): void {
+        this.requestCapability(MatrixCapabilities.MSC4533RtcLivekitDelegateDelayedLeave);
     }
 
     /**
@@ -901,6 +927,54 @@ export class WidgetApi extends EventEmitter {
             WidgetApiFromWidgetAction.MSC4039DownloadFileAction,
             data,
         );
+    }
+
+    /**
+     * Obtains a JWT for a LiveKit SFU, by asking the client to call the homeserver's
+     * `/rtc/livekit/get_token` endpoint on the widget's behalf.
+     * @param data The request data, which the client uses as the request body verbatim.
+     * @returns Resolves to the response body of the endpoint, verbatim.
+     * @see {@link https://github.com/matrix-org/matrix-spec-proposals/pull/4533|MSC4533}
+     */
+    public async getRtcLivekitToken(
+        data: IRtcLivekitGetTokenFromWidgetRequestData,
+    ): Promise<IRtcLivekitGetTokenFromWidgetResponseData> {
+        const versions = await this.getClientVersions();
+        if (!versions.includes(UnstableApiVersion.MSC4533)) {
+            throw new Error("The rtc_livekit_get_token action is not supported by the client.");
+        }
+
+        return this.transport.send<IRtcLivekitGetTokenFromWidgetRequestData, IRtcLivekitGetTokenFromWidgetResponseData>(
+            WidgetApiFromWidgetAction.MSC4533RtcLivekitGetToken,
+            data,
+        );
+    }
+
+    /**
+     * Hands a MatrixRTC session's delayed leave event over to the server, by asking the
+     * client to call the homeserver's `/rtc/livekit/delegate_delayed_leave` endpoint on
+     * the widget's behalf.
+     *
+     * Homeservers may not support this endpoint, in which case the request rejects with a
+     * {@link WidgetApiResponseError} whose `matrix_api_error` reports an HTTP 404 with
+     * `M_UNRECOGNIZED`. The widget is then responsible for refreshing the delayed leave
+     * event itself.
+     * @param data The request data, which the client uses as the request body verbatim.
+     * @returns Resolves to the response body of the endpoint, verbatim.
+     * @see {@link https://github.com/matrix-org/matrix-spec-proposals/pull/4533|MSC4533}
+     */
+    public async delegateRtcLivekitDelayedLeave(
+        data: IRtcLivekitDelegateDelayedLeaveFromWidgetRequestData,
+    ): Promise<IRtcLivekitDelegateDelayedLeaveFromWidgetResponseData> {
+        const versions = await this.getClientVersions();
+        if (!versions.includes(UnstableApiVersion.MSC4533)) {
+            throw new Error("The rtc_livekit_delegate_delayed_leave action is not supported by the client.");
+        }
+
+        return this.transport.send<
+            IRtcLivekitDelegateDelayedLeaveFromWidgetRequestData,
+            IRtcLivekitDelegateDelayedLeaveFromWidgetResponseData
+        >(WidgetApiFromWidgetAction.MSC4533RtcLivekitDelegateDelayedLeave, data);
     }
 
     /**

--- a/src/driver/WidgetDriver.ts
+++ b/src/driver/WidgetDriver.ts
@@ -24,6 +24,10 @@ import {
     ITurnServer,
     IWidgetApiErrorResponseDataDetails,
     IRtcTransport,
+    IRtcLivekitGetTokenFromWidgetRequestData,
+    IRtcLivekitGetTokenFromWidgetResponseData,
+    IRtcLivekitDelegateDelayedLeaveFromWidgetRequestData,
+    IRtcLivekitDelegateDelayedLeaveFromWidgetResponseData,
 } from "..";
 
 export interface ISendEventDetails {
@@ -489,6 +493,35 @@ export abstract class WidgetDriver {
      */
     public downloadFile(contentUri: string): Promise<{ file: XMLHttpRequestBodyInit }> {
         throw new Error("Download file is not implemented");
+    }
+
+    /**
+     * Obtains a JWT for a LiveKit SFU by calling the homeserver's
+     * `/rtc/livekit/get_token` endpoint on the widget's behalf. The widget API
+     * will have already verified that the widget has permission to do so.
+     * @param data The request data, to be used as the request body verbatim.
+     * @returns Resolves to the response body of the endpoint, verbatim.
+     * @see {@link https://github.com/matrix-org/matrix-spec-proposals/pull/4533|MSC4533}
+     */
+    public getRtcLivekitToken(
+        data: IRtcLivekitGetTokenFromWidgetRequestData,
+    ): Promise<IRtcLivekitGetTokenFromWidgetResponseData> {
+        throw new Error("Getting a LiveKit token is not implemented");
+    }
+
+    /**
+     * Hands a MatrixRTC session's delayed leave event over to the server by
+     * calling the homeserver's `/rtc/livekit/delegate_delayed_leave` endpoint on
+     * the widget's behalf. The widget API will have already verified that the
+     * widget has permission to do so.
+     * @param data The request data, to be used as the request body verbatim.
+     * @returns Resolves to the response body of the endpoint, verbatim.
+     * @see {@link https://github.com/matrix-org/matrix-spec-proposals/pull/4533|MSC4533}
+     */
+    public delegateRtcLivekitDelayedLeave(
+        data: IRtcLivekitDelegateDelayedLeaveFromWidgetRequestData,
+    ): Promise<IRtcLivekitDelegateDelayedLeaveFromWidgetResponseData> {
+        throw new Error("Delegating a LiveKit delayed leave is not implemented");
     }
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ export * from "./interfaces/UpdateDelayedEventAction";
 export type * from "./interfaces/UpdateStateAction";
 export type * from "./interfaces/UploadFileAction";
 export type * from "./interfaces/DownloadFileAction";
+export type * from "./interfaces/RtcLivekitActions";
 export type * from "./interfaces/ThemeChangeAction";
 export type * from "./interfaces/LanguageChangeAction";
 

--- a/src/interfaces/ApiVersion.ts
+++ b/src/interfaces/ApiVersion.ts
@@ -34,6 +34,7 @@ export enum UnstableApiVersion {
     MSC3973 = "org.matrix.msc3973",
     MSC4039 = "org.matrix.msc4039",
     MSC4515 = "org.matrix.msc4515",
+    MSC4533 = "org.matrix.msc4533",
 }
 
 export type ApiVersion = MatrixApiVersion | UnstableApiVersion | string;
@@ -55,4 +56,5 @@ export const CurrentApiVersions: ApiVersion[] = [
     UnstableApiVersion.MSC3973,
     UnstableApiVersion.MSC4039,
     UnstableApiVersion.MSC4515,
+    UnstableApiVersion.MSC4533,
 ];

--- a/src/interfaces/Capabilities.ts
+++ b/src/interfaces/Capabilities.ts
@@ -65,6 +65,14 @@ export enum MatrixCapabilities {
      * @experimental It is not recommended to rely on this existing - it can be removed without notice.
      */
     MSC4515RtcTransports = "org.matrix.msc4515.rtc_transports",
+    /**
+     * @experimental It is not recommended to rely on this existing - it can be removed without notice.
+     */
+    MSC4533RtcLivekitGetToken = "org.matrix.msc4533.rtc_livekit_get_token",
+    /**
+     * @experimental It is not recommended to rely on this existing - it can be removed without notice.
+     */
+    MSC4533RtcLivekitDelegateDelayedLeave = "org.matrix.msc4533.rtc_livekit_delegate_delayed_leave",
 }
 
 export type Capability = MatrixCapabilities | string;

--- a/src/interfaces/RtcLivekitActions.ts
+++ b/src/interfaces/RtcLivekitActions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The Matrix.org Foundation C.I.C.
+ * Copyright 2026 The Matrix.org Foundation C.I.C.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/interfaces/RtcLivekitActions.ts
+++ b/src/interfaces/RtcLivekitActions.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 The Matrix.org Foundation C.I.C.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { IWidgetApiRequest, IWidgetApiRequestData } from "./IWidgetApiRequest";
+import { IWidgetApiResponseData } from "./IWidgetApiResponse";
+import { WidgetApiFromWidgetAction } from "./WidgetApiAction";
+
+/**
+ * The MatrixRTC member a LiveKit request is made for.
+ * @see {@link https://github.com/matrix-org/matrix-spec-proposals/pull/4195|MSC4195}
+ */
+export interface IRtcLivekitMember {
+    /** The identifier of the member within the MatrixRTC session. */
+    id: string;
+    /** The device ID the member claims to be using. */
+    claimed_device_id?: string; // eslint-disable-line camelcase
+}
+
+export interface IRtcLivekitGetTokenFromWidgetRequestData extends IWidgetApiRequestData {
+    /** The name of the homeserver hosting the MatrixRTC session. */
+    server_name: string; // eslint-disable-line camelcase
+    /** The URL of the LiveKit SFU to obtain a token for. */
+    url: string;
+    /** The room the MatrixRTC session belongs to. */
+    room_id: string; // eslint-disable-line camelcase
+    /** The MatrixRTC session (slot) to join. */
+    slot_id: string; // eslint-disable-line camelcase
+    member: IRtcLivekitMember;
+}
+
+export interface IRtcLivekitGetTokenFromWidgetActionRequest extends IWidgetApiRequest {
+    action: WidgetApiFromWidgetAction.MSC4533RtcLivekitGetToken;
+    data: IRtcLivekitGetTokenFromWidgetRequestData;
+}
+
+export interface IRtcLivekitGetTokenFromWidgetResponseData extends IWidgetApiResponseData {
+    /** The JWT to authenticate against the SFU with. */
+    jwt: string;
+}
+
+export interface IRtcLivekitGetTokenFromWidgetActionResponse extends IRtcLivekitGetTokenFromWidgetActionRequest {
+    response: IRtcLivekitGetTokenFromWidgetResponseData;
+}
+
+export interface IRtcLivekitDelegateDelayedLeaveFromWidgetRequestData extends IWidgetApiRequestData {
+    /** The room the MatrixRTC session belongs to. */
+    room_id: string; // eslint-disable-line camelcase
+    /** The MatrixRTC session (slot) the delayed leave event belongs to. */
+    slot_id: string; // eslint-disable-line camelcase
+    member: IRtcLivekitMember;
+    /** The ID of the delayed leave event to hand over to the server. */
+    delay_id: string; // eslint-disable-line camelcase
+}
+
+export interface IRtcLivekitDelegateDelayedLeaveFromWidgetActionRequest extends IWidgetApiRequest {
+    action: WidgetApiFromWidgetAction.MSC4533RtcLivekitDelegateDelayedLeave;
+    data: IRtcLivekitDelegateDelayedLeaveFromWidgetRequestData;
+}
+
+export interface IRtcLivekitDelegateDelayedLeaveFromWidgetResponseData extends IWidgetApiResponseData {
+    // nothing
+}
+
+export interface IRtcLivekitDelegateDelayedLeaveFromWidgetActionResponse
+    extends IRtcLivekitDelegateDelayedLeaveFromWidgetActionRequest {
+    response: IRtcLivekitDelegateDelayedLeaveFromWidgetResponseData;
+}

--- a/src/interfaces/WidgetApiAction.ts
+++ b/src/interfaces/WidgetApiAction.ts
@@ -97,6 +97,16 @@ export enum WidgetApiFromWidgetAction {
      * @experimental It is not recommended to rely on this existing - it can be removed without notice.
      */
     MSC4515GetRtcTransports = "org.matrix.msc4515.get_rtc_transports",
+
+    /**
+     * @experimental It is not recommended to rely on this existing - it can be removed without notice.
+     */
+    MSC4533RtcLivekitGetToken = "org.matrix.msc4533.rtc_livekit_get_token",
+
+    /**
+     * @experimental It is not recommended to rely on this existing - it can be removed without notice.
+     */
+    MSC4533RtcLivekitDelegateDelayedLeave = "org.matrix.msc4533.rtc_livekit_delegate_delayed_leave",
 }
 
 export type WidgetApiAction = WidgetApiToWidgetAction | WidgetApiFromWidgetAction | string;

--- a/test/ClientWidgetApi-test.ts
+++ b/test/ClientWidgetApi-test.ts
@@ -36,6 +36,8 @@ import {
     IMatrixApiError,
     INavigateActionRequest,
     IReadEventFromWidgetActionRequest,
+    IRtcLivekitDelegateDelayedLeaveFromWidgetActionRequest,
+    IRtcLivekitGetTokenFromWidgetActionRequest,
     ISendEventFromWidgetActionRequest,
     ISendToDeviceFromWidgetActionRequest,
     IUpdateDelayedEventFromWidgetActionRequest,
@@ -142,6 +144,8 @@ describe("ClientWidgetApi", () => {
             getRtcTransports: jest.fn(),
             uploadFile: jest.fn(),
             downloadFile: jest.fn(),
+            getRtcLivekitToken: jest.fn(),
+            delegateRtcLivekitDelayedLeave: jest.fn(),
             getKnownRooms: jest.fn(() => []),
             processError: jest.fn(),
             sendStickyEvent: jest.fn(),
@@ -3151,6 +3155,204 @@ describe("ClientWidgetApi", () => {
                                 error: "failed to download a file",
                                 reason: "Too many requests",
                                 retry_after_ms: 2000,
+                            },
+                        } satisfies IMatrixApiError,
+                    },
+                });
+            });
+        });
+    });
+
+    describe("org.matrix.msc4533.rtc_livekit_get_token action", () => {
+        const data = {
+            server_name: "example.org",
+            url: "wss://livekit.example.org",
+            room_id: "!room-id",
+            slot_id: "slot-id",
+            member: { id: "member-id", claimed_device_id: "DEVICEID" },
+        };
+
+        function makeEvent(): IRtcLivekitGetTokenFromWidgetActionRequest {
+            return {
+                api: WidgetApiDirection.FromWidget,
+                widgetId: "test",
+                requestId: "0",
+                action: WidgetApiFromWidgetAction.MSC4533RtcLivekitGetToken,
+                data,
+            };
+        }
+
+        it("should handle and process the request", async () => {
+            driver.getRtcLivekitToken.mockResolvedValue({ jwt: "the-jwt" });
+
+            const event = makeEvent();
+
+            await loadIframe([MatrixCapabilities.MSC4533RtcLivekitGetToken]);
+
+            emitEvent(new CustomEvent("", { detail: event }));
+
+            await waitFor(() => {
+                expect(transport.reply).toHaveBeenCalledWith(event, { jwt: "the-jwt" });
+            });
+
+            expect(driver.getRtcLivekitToken).toHaveBeenCalledWith(data);
+        });
+
+        it("should reject requests when the capability was not requested", async () => {
+            const event = makeEvent();
+
+            await loadIframe([]); // Without the required capability
+
+            emitEvent(new CustomEvent("", { detail: event }));
+
+            await waitFor(() => {
+                expect(transport.reply).toHaveBeenCalledWith(event, {
+                    error: { message: "Missing capability" },
+                });
+            });
+
+            expect(driver.getRtcLivekitToken).not.toHaveBeenCalled();
+        });
+
+        it("should reject requests when the driver throws an exception", async () => {
+            driver.getRtcLivekitToken.mockRejectedValue(new Error("M_LIMIT_EXCEEDED: Too many requests"));
+
+            const event = makeEvent();
+
+            await loadIframe([MatrixCapabilities.MSC4533RtcLivekitGetToken]);
+
+            emitEvent(new CustomEvent("", { detail: event }));
+
+            await waitFor(() => {
+                expect(transport.reply).toHaveBeenCalledWith(event, {
+                    error: { message: "Unexpected error while getting a LiveKit token" },
+                });
+            });
+        });
+
+        it("should reject with Matrix API error response thrown by driver", async () => {
+            driver.processError.mockImplementation(processCustomMatrixError);
+            driver.getRtcLivekitToken.mockRejectedValue(
+                new CustomMatrixError("failed to get a token", 404, "M_UNRECOGNIZED", {
+                    reason: "Unrecognized request",
+                }),
+            );
+
+            const event = makeEvent();
+
+            await loadIframe([MatrixCapabilities.MSC4533RtcLivekitGetToken]);
+
+            emitEvent(new CustomEvent("", { detail: event }));
+
+            await waitFor(() => {
+                expect(transport.reply).toHaveBeenCalledWith(event, {
+                    error: {
+                        message: "Unexpected error while getting a LiveKit token",
+                        matrix_api_error: {
+                            http_status: 404,
+                            http_headers: {},
+                            url: "",
+                            response: {
+                                errcode: "M_UNRECOGNIZED",
+                                error: "failed to get a token",
+                                reason: "Unrecognized request",
+                            },
+                        } satisfies IMatrixApiError,
+                    },
+                });
+            });
+        });
+    });
+
+    describe("org.matrix.msc4533.rtc_livekit_delegate_delayed_leave action", () => {
+        const data = {
+            room_id: "!room-id",
+            slot_id: "slot-id",
+            member: { id: "member-id", claimed_device_id: "DEVICEID" },
+            delay_id: "delay-id",
+        };
+
+        function makeEvent(): IRtcLivekitDelegateDelayedLeaveFromWidgetActionRequest {
+            return {
+                api: WidgetApiDirection.FromWidget,
+                widgetId: "test",
+                requestId: "0",
+                action: WidgetApiFromWidgetAction.MSC4533RtcLivekitDelegateDelayedLeave,
+                data,
+            };
+        }
+
+        it("should handle and process the request", async () => {
+            driver.delegateRtcLivekitDelayedLeave.mockResolvedValue({});
+
+            const event = makeEvent();
+
+            await loadIframe([MatrixCapabilities.MSC4533RtcLivekitDelegateDelayedLeave]);
+
+            emitEvent(new CustomEvent("", { detail: event }));
+
+            await waitFor(() => {
+                expect(transport.reply).toHaveBeenCalledWith(event, {});
+            });
+
+            expect(driver.delegateRtcLivekitDelayedLeave).toHaveBeenCalledWith(data);
+        });
+
+        it("should reject requests when the capability was not requested", async () => {
+            const event = makeEvent();
+
+            await loadIframe([]); // Without the required capability
+
+            emitEvent(new CustomEvent("", { detail: event }));
+
+            await waitFor(() => {
+                expect(transport.reply).toHaveBeenCalledWith(event, {
+                    error: { message: "Missing capability" },
+                });
+            });
+
+            expect(driver.delegateRtcLivekitDelayedLeave).not.toHaveBeenCalled();
+        });
+
+        it("should reject requests when the driver throws an exception", async () => {
+            driver.delegateRtcLivekitDelayedLeave.mockRejectedValue(new Error("M_LIMIT_EXCEEDED: Too many requests"));
+
+            const event = makeEvent();
+
+            await loadIframe([MatrixCapabilities.MSC4533RtcLivekitDelegateDelayedLeave]);
+
+            emitEvent(new CustomEvent("", { detail: event }));
+
+            await waitFor(() => {
+                expect(transport.reply).toHaveBeenCalledWith(event, {
+                    error: { message: "Unexpected error while delegating a LiveKit delayed leave" },
+                });
+            });
+        });
+
+        it("should relay a Matrix API error for homeservers that lack the endpoint", async () => {
+            driver.processError.mockImplementation(processCustomMatrixError);
+            driver.delegateRtcLivekitDelayedLeave.mockRejectedValue(
+                new CustomMatrixError("Unrecognized request", 404, "M_UNRECOGNIZED", {}),
+            );
+
+            const event = makeEvent();
+
+            await loadIframe([MatrixCapabilities.MSC4533RtcLivekitDelegateDelayedLeave]);
+
+            emitEvent(new CustomEvent("", { detail: event }));
+
+            await waitFor(() => {
+                expect(transport.reply).toHaveBeenCalledWith(event, {
+                    error: {
+                        message: "Unexpected error while delegating a LiveKit delayed leave",
+                        matrix_api_error: {
+                            http_status: 404,
+                            http_headers: {},
+                            url: "",
+                            response: {
+                                errcode: "M_UNRECOGNIZED",
+                                error: "Unrecognized request",
                             },
                         } satisfies IMatrixApiError,
                     },

--- a/test/WidgetApi-test.ts
+++ b/test/WidgetApi-test.ts
@@ -23,6 +23,12 @@ import { ISendEventFromWidgetResponseData } from "../src/interfaces/SendEventAct
 import { ISupportedVersionsActionResponseData } from "../src/interfaces/SupportedVersionsAction";
 import { IUploadFileActionFromWidgetResponseData } from "../src/interfaces/UploadFileAction";
 import { IDownloadFileActionFromWidgetResponseData } from "../src/interfaces/DownloadFileAction";
+import {
+    IRtcLivekitDelegateDelayedLeaveFromWidgetRequestData,
+    IRtcLivekitDelegateDelayedLeaveFromWidgetResponseData,
+    IRtcLivekitGetTokenFromWidgetRequestData,
+    IRtcLivekitGetTokenFromWidgetResponseData,
+} from "../src/interfaces/RtcLivekitActions";
 import { IUserDirectorySearchFromWidgetResponseData } from "../src/interfaces/UserDirectorySearchAction";
 import { WidgetApiFromWidgetAction } from "../src/interfaces/WidgetApiAction";
 import { WidgetApi, WidgetApiResponseError } from "../src/WidgetApi";
@@ -862,6 +868,161 @@ describe("WidgetApi", () => {
             } as IWidgetApiErrorResponseData);
 
             await expect(widgetApi.downloadFile("mxc://example.com/test_file")).rejects.toThrow(
+                new WidgetApiResponseError("An error occurred", errorDetails),
+            );
+        });
+    });
+
+    describe("getRtcLivekitToken", () => {
+        const data: IRtcLivekitGetTokenFromWidgetRequestData = {
+            server_name: "example.org",
+            url: "wss://livekit.example.org",
+            room_id: "!room-id",
+            slot_id: "slot-id",
+            member: { id: "member-id", claimed_device_id: "DEVICEID" },
+        };
+
+        it("should forward the request to the ClientWidgetApi", async () => {
+            widgetTransportHelper.queueResponse({
+                supported_versions: [UnstableApiVersion.MSC4533],
+            } as ISupportedVersionsActionResponseData);
+            widgetTransportHelper.queueResponse({ jwt: "the-jwt" } as IRtcLivekitGetTokenFromWidgetResponseData);
+
+            await expect(widgetApi.getRtcLivekitToken(data)).resolves.toEqual({ jwt: "the-jwt" });
+
+            expect(widgetTransportHelper.nextTrackedRequest()).not.toBeUndefined();
+            expect(widgetTransportHelper.nextTrackedRequest()).toEqual({
+                action: WidgetApiFromWidgetAction.MSC4533RtcLivekitGetToken,
+                data,
+            } satisfies SendRequestArgs);
+        });
+
+        it("should reject the request if the api is not supported", async () => {
+            widgetTransportHelper.queueResponse({ supported_versions: [] } as ISupportedVersionsActionResponseData);
+
+            await expect(widgetApi.getRtcLivekitToken(data)).rejects.toThrow(
+                "The rtc_livekit_get_token action is not supported by the client.",
+            );
+
+            const request = widgetTransportHelper.nextTrackedRequest();
+            expect(request).not.toBeUndefined();
+            expect(request).not.toEqual({
+                action: WidgetApiFromWidgetAction.MSC4533RtcLivekitGetToken,
+                data: expect.anything(),
+            } satisfies SendRequestArgs);
+        });
+
+        it("should handle an error", async () => {
+            widgetTransportHelper.queueResponse({
+                supported_versions: [UnstableApiVersion.MSC4533],
+            } as ISupportedVersionsActionResponseData);
+            widgetTransportHelper.queueResponse({ error: { message: "An error occurred" } });
+
+            await expect(widgetApi.getRtcLivekitToken(data)).rejects.toThrow("An error occurred");
+        });
+
+        it("should handle an error with details", async () => {
+            widgetTransportHelper.queueResponse({
+                supported_versions: [UnstableApiVersion.MSC4533],
+            } as ISupportedVersionsActionResponseData);
+
+            const errorDetails: IWidgetApiErrorResponseDataDetails = {
+                matrix_api_error: {
+                    http_status: 404,
+                    http_headers: {},
+                    url: "",
+                    response: {
+                        errcode: "M_UNRECOGNIZED",
+                        error: "Unrecognized request",
+                    },
+                },
+            };
+
+            widgetTransportHelper.queueResponse({
+                error: {
+                    message: "An error occurred",
+                    ...errorDetails,
+                },
+            } as IWidgetApiErrorResponseData);
+
+            await expect(widgetApi.getRtcLivekitToken(data)).rejects.toThrow(
+                new WidgetApiResponseError("An error occurred", errorDetails),
+            );
+        });
+    });
+
+    describe("delegateRtcLivekitDelayedLeave", () => {
+        const data: IRtcLivekitDelegateDelayedLeaveFromWidgetRequestData = {
+            room_id: "!room-id",
+            slot_id: "slot-id",
+            member: { id: "member-id", claimed_device_id: "DEVICEID" },
+            delay_id: "delay-id",
+        };
+
+        it("should forward the request to the ClientWidgetApi", async () => {
+            widgetTransportHelper.queueResponse({
+                supported_versions: [UnstableApiVersion.MSC4533],
+            } as ISupportedVersionsActionResponseData);
+            widgetTransportHelper.queueResponse({} as IRtcLivekitDelegateDelayedLeaveFromWidgetResponseData);
+
+            await expect(widgetApi.delegateRtcLivekitDelayedLeave(data)).resolves.toEqual({});
+
+            expect(widgetTransportHelper.nextTrackedRequest()).not.toBeUndefined();
+            expect(widgetTransportHelper.nextTrackedRequest()).toEqual({
+                action: WidgetApiFromWidgetAction.MSC4533RtcLivekitDelegateDelayedLeave,
+                data,
+            } satisfies SendRequestArgs);
+        });
+
+        it("should reject the request if the api is not supported", async () => {
+            widgetTransportHelper.queueResponse({ supported_versions: [] } as ISupportedVersionsActionResponseData);
+
+            await expect(widgetApi.delegateRtcLivekitDelayedLeave(data)).rejects.toThrow(
+                "The rtc_livekit_delegate_delayed_leave action is not supported by the client.",
+            );
+
+            const request = widgetTransportHelper.nextTrackedRequest();
+            expect(request).not.toBeUndefined();
+            expect(request).not.toEqual({
+                action: WidgetApiFromWidgetAction.MSC4533RtcLivekitDelegateDelayedLeave,
+                data: expect.anything(),
+            } satisfies SendRequestArgs);
+        });
+
+        it("should handle an error", async () => {
+            widgetTransportHelper.queueResponse({
+                supported_versions: [UnstableApiVersion.MSC4533],
+            } as ISupportedVersionsActionResponseData);
+            widgetTransportHelper.queueResponse({ error: { message: "An error occurred" } });
+
+            await expect(widgetApi.delegateRtcLivekitDelayedLeave(data)).rejects.toThrow("An error occurred");
+        });
+
+        it("should surface an unsupported endpoint as a Matrix API error", async () => {
+            widgetTransportHelper.queueResponse({
+                supported_versions: [UnstableApiVersion.MSC4533],
+            } as ISupportedVersionsActionResponseData);
+
+            const errorDetails: IWidgetApiErrorResponseDataDetails = {
+                matrix_api_error: {
+                    http_status: 404,
+                    http_headers: {},
+                    url: "",
+                    response: {
+                        errcode: "M_UNRECOGNIZED",
+                        error: "Unrecognized request",
+                    },
+                },
+            };
+
+            widgetTransportHelper.queueResponse({
+                error: {
+                    message: "An error occurred",
+                    ...errorDetails,
+                },
+            } as IWidgetApiErrorResponseData);
+
+            await expect(widgetApi.delegateRtcLivekitDelayedLeave(data)).rejects.toThrow(
                 new WidgetApiResponseError("An error occurred", errorDetails),
             );
         });


### PR DESCRIPTION
Adds two new `actions` from [MSC4533](https://github.com/matrix-org/matrix-spec-proposals/pull/4533)

POST `/_matrix/client/v1/rtc/livekit/get_token` to obtain the JWT for the SFU.
POST `/_matrix/client/v1/rtc/livekit/delegate_delayed_leave` to hand the session's delayed leave event over to the server.